### PR TITLE
Fix doc LONGPORT_ACCESS_TOKEN typo

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -60,7 +60,7 @@ Or use this config:
       "env": {
         "LONGPORT_APP_KEY": "your-app-key",
         "LONGPORT_APP_SECRET": "your-app-secret",
-        "LONGPORT_APP_PASSPHRASE": "your-aaccess-token"
+        "LONGPORT_ACCESS_TOKEN": "your-aaccess-token"
       }
     }
   }


### PR DESCRIPTION
提供的json配置示例 env 名称有误，导致mcp服务启动失败