### PR TITLE
fix: correct QuoteContext cache expiry checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+- **Rust:** Fix incorrect cache expiry checks in `QuoteContext`.
 - **All bindings:** Correct `SecurityStaticInfo.dividend_yield` doc comment from "Dividend yield" (ratio) to "Dividend" (per share amount) across all language SDKs (Rust, Python, Node.js, Java, C, C++).
 - **All bindings:** `create_topic` now returns the topic ID (`String`) instead of `OwnedTopic` to avoid deserialization errors when the API response omits optional fields.
 

--- a/rust/src/quote/cache.rs
+++ b/rust/src/quote/cache.rs
@@ -42,7 +42,7 @@ where
     {
         let mut inner = self.inner.lock().await;
         match inner.values.get(&key) {
-            Some(Item { deadline, value }) if deadline < &Instant::now() => Ok(value.clone()),
+            Some(Item { deadline, value }) if deadline > &Instant::now() => Ok(value.clone()),
             _ => {
                 let value = f(key.clone()).await?;
                 let deadline = Instant::now() + inner.timeout;


### PR DESCRIPTION
The previous logic used the wrong comparison between `deadline` and `Instant::now()`. Before expiry, it bypassed the cache and refetched on every call, sliding the deadline forward each time. After expiry, it kept returning the stale entry for the lifetime of the `QuoteContext`.