### PR TITLE
fix(ci): pass GITHUB_TOKEN to napi prepublish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -719,6 +719,7 @@ jobs:
         working-directory: ./nodejs
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-java-sdk:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

- `napi prepublish -t npm` needs `GITHUB_TOKEN` explicitly passed via `env:` to create the GitHub Release. Without it the request is unauthenticated (401).

## Fix

Added `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the `Publish` step in `publish-nodejs-sdk` job.