### PR TITLE
fix(calendar): expose next_date cursor in finance_calendar response

### DIFF
--- a/c/csrc/include/longbridge.h
+++ b/c/csrc/include/longbridge.h
@@ -7110,6 +7110,10 @@ typedef struct lb_calendar_events_response_t {
    * Number of elements in the `list` array.
    */
   uintptr_t num_list;
+  /**
+   * Pagination cursor; pass as start to fetch the next page, empty when there are no more pages.
+   */
+  const char *next_date;
 } lb_calendar_events_response_t;
 
 /**

--- a/c/src/calendar_context/types.rs
+++ b/c/src/calendar_context/types.rs
@@ -198,7 +198,8 @@ pub struct CCalendarEventsResponse {
     pub list: *const CCalendarDateGroup,
     /// Number of elements in the `list` array.
     pub num_list: usize,
-    /// Pagination cursor; pass as start to fetch the next page, empty when there are no more pages.
+    /// Pagination cursor; pass as start to fetch the next page, empty when
+    /// there are no more pages.
     pub next_date: *const c_char,
 }
 pub(crate) struct CCalendarEventsResponseOwned {

--- a/c/src/calendar_context/types.rs
+++ b/c/src/calendar_context/types.rs
@@ -198,16 +198,20 @@ pub struct CCalendarEventsResponse {
     pub list: *const CCalendarDateGroup,
     /// Number of elements in the `list` array.
     pub num_list: usize,
+    /// Pagination cursor; pass as start to fetch the next page, empty when there are no more pages.
+    pub next_date: *const c_char,
 }
 pub(crate) struct CCalendarEventsResponseOwned {
     date: CString,
     list: CVec<CCalendarDateGroupOwned>,
+    next_date: CString,
 }
 impl From<CalendarEventsResponse> for CCalendarEventsResponseOwned {
     fn from(v: CalendarEventsResponse) -> Self {
         Self {
             date: v.date.into(),
             list: v.list.into(),
+            next_date: v.next_date.into(),
         }
     }
 }
@@ -218,6 +222,7 @@ impl ToFFI for CCalendarEventsResponseOwned {
             date: self.date.to_ffi_type(),
             list: self.list.to_ffi_type(),
             num_list: self.list.len(),
+            next_date: self.next_date.to_ffi_type(),
         }
     }
 }

--- a/cpp/include/calendar_context.hpp
+++ b/cpp/include/calendar_context.hpp
@@ -26,7 +26,8 @@ struct CalendarEventInfo { std::string symbol; std::string market; std::string c
 /// Calendar events grouped by date.
 struct CalendarDateGroup { std::string date; int32_t count; std::vector<CalendarEventInfo> infos; };
 /// Response for finance_calendar — events grouped by date within the requested range.
-struct CalendarEventsResponse { std::string date; std::vector<CalendarDateGroup> list; };
+/// Response for finance_calendar — events grouped by date within the requested range.
+struct CalendarEventsResponse { std::string date; std::vector<CalendarDateGroup> list; std::string next_date; };
 
 /// Financial calendar context — earnings, dividends, splits, IPOs, macro data.
 class CalendarContext {

--- a/cpp/src/calendar_context.cpp
+++ b/cpp/src/calendar_context.cpp
@@ -29,6 +29,7 @@ void CalendarContext::finance_calendar(CalendarCategory category, const std::str
         auto* r = (const lb_calendar_events_response_t*)res->data;
         CalendarEventsResponse resp;
         resp.date = r->date;
+        resp.next_date = r->next_date ? r->next_date : "";
         for (size_t i = 0; i < r->num_list; ++i) {
           CalendarDateGroup grp; grp.date = r->list[i].date; grp.count = r->list[i].count;
           for (size_t j = 0; j < r->list[i].num_infos; ++j) {

--- a/java/javasrc/src/main/java/com/longbridge/calendar/CalendarEventsResponse.java
+++ b/java/javasrc/src/main/java/com/longbridge/calendar/CalendarEventsResponse.java
@@ -6,4 +6,6 @@ public class CalendarEventsResponse {
     public String date;
     /** Per-day event groups. */
     public CalendarDateGroup[] list;
+    /** Pagination cursor; pass as start to fetch the next page, empty when there are no more pages. */
+    public String nextDate;
 }

--- a/java/src/types/classes.rs
+++ b/java/src/types/classes.rs
@@ -1261,7 +1261,8 @@ impl_java_class!(
     [
         date,
         #[java(objarray)]
-        list
+        list,
+        next_date
     ]
 );
 

--- a/nodejs/index.d.ts
+++ b/nodejs/index.d.ts
@@ -3385,6 +3385,8 @@ export interface CalendarEventsResponse {
   date: string
   /** Per-day event groups */
   list: Array<CalendarDateGroup>
+  /** Pagination cursor; pass as start to fetch the next page, empty when there are no more pages */
+  nextDate: string
 }
 
 export declare const enum CashFlowDirection {

--- a/python/pysrc/longbridge/openapi.pyi
+++ b/python/pysrc/longbridge/openapi.pyi
@@ -10706,6 +10706,8 @@ class CalendarEventsResponse:
     """Start date of the query window"""
     list: list[CalendarDateGroup]
     """Per-day event groups"""
+    next_date: str
+    """Pagination cursor; pass as start to fetch the next page, empty when there are no more pages"""
 
 
 class CalendarCategory:

--- a/rust/src/calendar/context.rs
+++ b/rust/src/calendar/context.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
+use std::collections::HashSet;
+
 use longbridge_httpcli::{HttpClient, Json, Method};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tracing::{Subscriber, dispatcher, instrument::WithSubscriber};
 
 use crate::{Config, Result, calendar::types::*};
@@ -48,6 +50,9 @@ impl CalendarContext {
 
     /// Get financial calendar events.
     ///
+    /// The endpoint is paginated via `next_date`; this method follows the
+    /// cursor automatically and returns the complete merged result.
+    ///
     /// Path: `GET /v1/quote/finance_calendar`
     pub async fn finance_calendar(
         &self,
@@ -66,6 +71,7 @@ impl CalendarContext {
             CalendarCategory::Meeting => "meeting",
             CalendarCategory::Merge => "merge",
         };
+
         #[derive(Serialize)]
         struct Query {
             date: String,
@@ -75,20 +81,61 @@ impl CalendarContext {
             #[serde(rename = "markets[]", skip_serializing_if = "Option::is_none")]
             markets: Option<String>,
         }
-        Ok(self
-            .0
-            .http_cli
-            .request(Method::GET, "/v1/quote/finance_calendar")
-            .query_params(Query {
-                date: start.into(),
-                date_end: end.into(),
-                types: cat_str,
-                markets: market,
-            })
-            .response::<Json<CalendarEventsResponse>>()
-            .send()
-            .with_subscriber(self.0.log_subscriber.clone())
-            .await?
-            .0)
+
+        // Internal page type that captures the pagination cursor.
+        #[derive(Deserialize)]
+        struct Page {
+            date: String,
+            #[serde(default)]
+            list: Vec<CalendarDateGroup>,
+            #[serde(default)]
+            next_date: String,
+        }
+
+        let end = end.into();
+        let mut cursor = start.into();
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut first_date = String::new();
+        let mut all_groups: Vec<CalendarDateGroup> = Vec::new();
+
+        loop {
+            let page = self
+                .0
+                .http_cli
+                .request(Method::GET, "/v1/quote/finance_calendar")
+                .query_params(Query {
+                    date: cursor,
+                    date_end: end.clone(),
+                    types: cat_str,
+                    markets: market.clone(),
+                })
+                .response::<Json<Page>>()
+                .send()
+                .with_subscriber(self.0.log_subscriber.clone())
+                .await?
+                .0;
+
+            if first_date.is_empty() {
+                first_date = page.date;
+            }
+
+            for mut grp in page.list {
+                grp.infos.retain(|info| seen.insert(info.id.clone()));
+                if !grp.infos.is_empty() {
+                    grp.count = grp.infos.len() as i32;
+                    all_groups.push(grp);
+                }
+            }
+
+            if page.next_date.is_empty() {
+                break;
+            }
+            cursor = page.next_date;
+        }
+
+        Ok(CalendarEventsResponse {
+            date: first_date,
+            list: all_groups,
+        })
     }
 }

--- a/rust/src/calendar/context.rs
+++ b/rust/src/calendar/context.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
-use std::collections::HashSet;
-
 use longbridge_httpcli::{HttpClient, Json, Method};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tracing::{Subscriber, dispatcher, instrument::WithSubscriber};
 
 use crate::{Config, Result, calendar::types::*};
@@ -50,8 +48,8 @@ impl CalendarContext {
 
     /// Get financial calendar events.
     ///
-    /// The endpoint is paginated via `next_date`; this method follows the
-    /// cursor automatically and returns the complete merged result.
+    /// The endpoint is paginated via `next_date`. When the returned
+    /// `next_date` is non-empty, pass it as `start` to fetch the next page.
     ///
     /// Path: `GET /v1/quote/finance_calendar`
     pub async fn finance_calendar(
@@ -71,7 +69,6 @@ impl CalendarContext {
             CalendarCategory::Meeting => "meeting",
             CalendarCategory::Merge => "merge",
         };
-
         #[derive(Serialize)]
         struct Query {
             date: String,
@@ -81,61 +78,20 @@ impl CalendarContext {
             #[serde(rename = "markets[]", skip_serializing_if = "Option::is_none")]
             markets: Option<String>,
         }
-
-        // Internal page type that captures the pagination cursor.
-        #[derive(Deserialize)]
-        struct Page {
-            date: String,
-            #[serde(default)]
-            list: Vec<CalendarDateGroup>,
-            #[serde(default)]
-            next_date: String,
-        }
-
-        let end = end.into();
-        let mut cursor = start.into();
-        let mut seen: HashSet<String> = HashSet::new();
-        let mut first_date = String::new();
-        let mut all_groups: Vec<CalendarDateGroup> = Vec::new();
-
-        loop {
-            let page = self
-                .0
-                .http_cli
-                .request(Method::GET, "/v1/quote/finance_calendar")
-                .query_params(Query {
-                    date: cursor,
-                    date_end: end.clone(),
-                    types: cat_str,
-                    markets: market.clone(),
-                })
-                .response::<Json<Page>>()
-                .send()
-                .with_subscriber(self.0.log_subscriber.clone())
-                .await?
-                .0;
-
-            if first_date.is_empty() {
-                first_date = page.date;
-            }
-
-            for mut grp in page.list {
-                grp.infos.retain(|info| seen.insert(info.id.clone()));
-                if !grp.infos.is_empty() {
-                    grp.count = grp.infos.len() as i32;
-                    all_groups.push(grp);
-                }
-            }
-
-            if page.next_date.is_empty() {
-                break;
-            }
-            cursor = page.next_date;
-        }
-
-        Ok(CalendarEventsResponse {
-            date: first_date,
-            list: all_groups,
-        })
+        Ok(self
+            .0
+            .http_cli
+            .request(Method::GET, "/v1/quote/finance_calendar")
+            .query_params(Query {
+                date: start.into(),
+                date_end: end.into(),
+                types: cat_str,
+                markets: market,
+            })
+            .response::<Json<CalendarEventsResponse>>()
+            .send()
+            .with_subscriber(self.0.log_subscriber.clone())
+            .await?
+            .0)
     }
 }

--- a/rust/src/calendar/types.rs
+++ b/rust/src/calendar/types.rs
@@ -12,6 +12,9 @@ pub struct CalendarEventsResponse {
     pub date: String,
     /// Per-day event groups
     pub list: Vec<CalendarDateGroup>,
+    /// Pagination cursor; pass as `start` to fetch the next page, empty when there are no more pages
+    #[serde(default)]
+    pub next_date: String,
 }
 
 /// Events for one calendar date

--- a/rust/src/calendar/types.rs
+++ b/rust/src/calendar/types.rs
@@ -12,7 +12,8 @@ pub struct CalendarEventsResponse {
     pub date: String,
     /// Per-day event groups
     pub list: Vec<CalendarDateGroup>,
-    /// Pagination cursor; pass as `start` to fetch the next page, empty when there are no more pages
+    /// Pagination cursor; pass as `start` to fetch the next page, empty when
+    /// there are no more pages
     #[serde(default)]
     pub next_date: String,
 }


### PR DESCRIPTION
## Summary

- The `/v1/quote/finance_calendar` endpoint paginates via a `next_date` cursor, but all SDK bindings were silently dropping it, making multi-page range queries return incomplete data (e.g. CRM.US, PDD.US, MRVL.US missing for a 2026-05-23→05-30 range)
- `next_date` is now returned as-is in `CalendarEventsResponse` across all language SDKs so callers can follow the cursor themselves

## Changes

| File | Change |
|------|--------|
| `rust/src/calendar/types.rs` | Add `next_date` to `CalendarEventsResponse` |
| `rust/src/calendar/context.rs` | Revert to single request (no internal pagination) |
| `c/src/calendar_context/types.rs` | Add `next_date` to C binding owned/FFI types |
| `c/csrc/include/longbridge.h` | Add `next_date` to `lb_calendar_events_response_t` |
| `cpp/include/calendar_context.hpp` | Add `next_date` to C++ `CalendarEventsResponse` struct |
| `cpp/src/calendar_context.cpp` | Populate `next_date` from C response in callback |
| `nodejs/index.d.ts` | Add `nextDate: string` to `CalendarEventsResponse` |
| `python/pysrc/longbridge/openapi.pyi` | Add `next_date: str` to `CalendarEventsResponse` |
| `java/.../CalendarEventsResponse.java` | Add `public String nextDate` |

## Related

- Go SDK fix: longbridge/openapi-go#fix/finance-calendar-pagination
- Issue: https://github.com/longbridge/developers/issues/1045#issuecomment-4591933632