### PR TITLE
feat(quote): symbol_to_counter_ids API with cached local-first resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **All languages:** `FundamentalContext` gains `etf_asset_allocation(symbol)` — queries `GET /v1/quote/etf-asset-allocation` for ETF asset allocation grouped by element type (`Holdings` / `Regional` / `AssetClass` / `Industry`); returns `AssetAllocationResponse` with report date, position ratios, localized names, and per-holding detail
 - **Rust:** new public `longbridge::counter` module — `symbol_to_counter_id`, `index_symbol_to_counter_id`, `counter_id_to_symbol`, and `is_etf`, backed by the embedded ETF + index + warrant directory, so downstream consumers (CLI / MCP) no longer need their own copies
+- **Rust:** `QuoteContext` gains `symbol_to_counter_ids(symbols)` (batch conversion via `POST /v1/quote/symbol-to-counter-ids`) and `resolve_counter_ids(symbols)` (local-first resolution with remote fallback) — remotely resolved entries are persisted to `~/.longbridge/cache/counter-ids.json` (override with `LONGBRIDGE_CACHE_DIR`) and consulted by subsequent `counter` lookups, so symbols missing from the embedded directory (e.g. newly listed ETFs) resolve correctly after the first query
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **All languages:** `FundamentalContext` gains `etf_asset_allocation(symbol)` — queries `GET /v1/quote/etf-asset-allocation` for ETF asset allocation grouped by element type (`Holdings` / `Regional` / `AssetClass` / `Industry`); returns `AssetAllocationResponse` with report date, position ratios, localized names, and per-holding detail
 - **Rust:** new public `longbridge::counter` module — `symbol_to_counter_id`, `index_symbol_to_counter_id`, `counter_id_to_symbol`, and `is_etf`, backed by the embedded ETF + index + warrant directory, so downstream consumers (CLI / MCP) no longer need their own copies
-- **Rust:** `QuoteContext` gains `symbol_to_counter_ids(symbols)` (batch conversion via `POST /v1/quote/symbol-to-counter-ids`) and `resolve_counter_ids(symbols)` (local-first resolution with remote fallback) — remotely resolved entries are persisted to `~/.longbridge/cache/counter-ids.json` (override with `LONGBRIDGE_CACHE_DIR`) and consulted by subsequent `counter` lookups, so symbols missing from the embedded directory (e.g. newly listed ETFs) resolve correctly after the first query
+- **Rust:** `QuoteContext` gains `symbol_to_counter_ids(symbols)` (batch conversion via `POST /v1/quote/symbol-to-counter-ids`) and `resolve_counter_ids(symbols)` (local-first resolution with remote fallback) — remotely resolved entries are persisted to `~/.longbridge/cache/counter-ids.csv` (one counter_id per line, override the directory with `LONGBRIDGE_CACHE_DIR`) and consulted by subsequent `counter` lookups, so symbols missing from the embedded directory (e.g. newly listed ETFs) resolve correctly after the first query
 
 ### Changed
 

--- a/rust/src/blocking/quote.rs
+++ b/rust/src/blocking/quote.rs
@@ -1213,4 +1213,23 @@ impl QuoteContextSync {
         self.rt
             .call(move |ctx| async move { ctx.short_trades(symbol, count).await })
     }
+
+    /// Batch convert symbols to counter IDs via the remote API
+    pub fn symbol_to_counter_ids(
+        &self,
+        symbols: Vec<String>,
+    ) -> Result<std::collections::HashMap<String, String>> {
+        self.rt
+            .call(move |ctx| async move { ctx.symbol_to_counter_ids(symbols).await })
+    }
+
+    /// Resolve counter IDs for symbols, local-first with remote fallback and
+    /// local caching
+    pub fn resolve_counter_ids(
+        &self,
+        symbols: Vec<String>,
+    ) -> Result<std::collections::HashMap<String, String>> {
+        self.rt
+            .call(move |ctx| async move { ctx.resolve_counter_ids(symbols).await })
+    }
 }

--- a/rust/src/quote/context.rs
+++ b/rust/src/quote/context.rs
@@ -2263,7 +2263,7 @@ impl QuoteContext {
         }
         if !unknown.is_empty() {
             let resolved = self.symbol_to_counter_ids(unknown.clone()).await?;
-            counter::cache_counter_ids(&resolved);
+            counter::cache_counter_ids(resolved.values().map(String::as_str));
             for symbol in unknown {
                 let counter_id = resolved
                     .get(&symbol)

--- a/rust/src/quote/context.rs
+++ b/rust/src/quote/context.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     sync::{Arc, RwLock},
     time::Duration,
 };
@@ -2197,6 +2198,81 @@ impl QuoteContext {
             .await?;
 
         Ok(())
+    }
+
+    // ── symbol_to_counter_ids ─────────────────────────────────────
+
+    /// Batch convert symbols to counter IDs via the remote API.
+    ///
+    /// Returns a map of `symbol → counter_id` (e.g. `DRAM.US` →
+    /// `ETF/US/DRAM`). Symbols the backend does not recognize are omitted
+    /// from the result.
+    ///
+    /// Path: `POST /v1/quote/symbol-to-counter-ids`
+    pub async fn symbol_to_counter_ids(
+        &self,
+        symbols: Vec<String>,
+    ) -> Result<HashMap<String, String>> {
+        #[derive(Debug, Serialize)]
+        struct Request {
+            ticker_regions: Vec<String>,
+        }
+        #[derive(Debug, Deserialize)]
+        struct Response {
+            #[serde(default)]
+            list: HashMap<String, String>,
+        }
+
+        let resp = self
+            .0
+            .http_cli
+            .request(Method::POST, "/v1/quote/symbol-to-counter-ids")
+            .body(Json(Request {
+                ticker_regions: symbols,
+            }))
+            .response::<Json<Response>>()
+            .send()
+            .with_subscriber(self.0.log_subscriber.clone())
+            .await?;
+        Ok(resp.0.list)
+    }
+
+    /// Resolve counter IDs for symbols, local-first with remote fallback.
+    ///
+    /// Symbols found in the embedded ETF / index / warrant directory (or in
+    /// the local cache of previous remote resolutions) are resolved without
+    /// network access. The remaining symbols are resolved in one batch via
+    /// [`symbol_to_counter_ids`](Self::symbol_to_counter_ids) and the results
+    /// are persisted to the local cache for subsequent lookups. Symbols the
+    /// backend does not recognize fall back to the default `ST/` conversion.
+    pub async fn resolve_counter_ids(
+        &self,
+        symbols: Vec<String>,
+    ) -> Result<HashMap<String, String>> {
+        use crate::utils::counter;
+
+        let mut result = HashMap::with_capacity(symbols.len());
+        let mut unknown = Vec::new();
+        for symbol in symbols {
+            match counter::lookup_counter_id(&symbol) {
+                Some(counter_id) => {
+                    result.insert(symbol, counter_id);
+                }
+                None => unknown.push(symbol),
+            }
+        }
+        if !unknown.is_empty() {
+            let resolved = self.symbol_to_counter_ids(unknown.clone()).await?;
+            counter::cache_counter_ids(&resolved);
+            for symbol in unknown {
+                let counter_id = resolved
+                    .get(&symbol)
+                    .cloned()
+                    .unwrap_or_else(|| counter::symbol_to_counter_id(&symbol));
+                result.insert(symbol, counter_id);
+            }
+        }
+        Ok(result)
     }
 }
 

--- a/rust/src/utils/counter.rs
+++ b/rust/src/utils/counter.rs
@@ -11,7 +11,7 @@
 //! to a local cache file and consulted on subsequent lookups.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     path::PathBuf,
     sync::{OnceLock, RwLock},
 };
@@ -35,17 +35,18 @@ fn special_counter_ids() -> &'static HashSet<&'static str> {
 
 // ── remote-resolved counter_id cache ──────────────────────────────
 
-static CACHED_COUNTER_IDS: OnceLock<RwLock<HashMap<String, String>>> = OnceLock::new();
+static CACHED_COUNTER_IDS: OnceLock<RwLock<HashSet<String>>> = OnceLock::new();
 
 #[cfg(test)]
 static TEST_CACHE_DIR: OnceLock<PathBuf> = OnceLock::new();
 
-/// Cache file path: `$LONGBRIDGE_CACHE_DIR/counter-ids.json`, defaulting to
-/// `~/.longbridge/cache/counter-ids.json`.
+/// Cache file path: `$LONGBRIDGE_CACHE_DIR/counter-ids.csv`, defaulting to
+/// `~/.longbridge/cache/counter-ids.csv` (one counter_id per line, same
+/// format as the embedded directory files).
 fn cache_file_path() -> Option<PathBuf> {
     #[cfg(test)]
     if let Some(dir) = TEST_CACHE_DIR.get() {
-        return Some(dir.join("counter-ids.json"));
+        return Some(dir.join("counter-ids.csv"));
     }
     let dir = match std::env::var_os("LONGBRIDGE_CACHE_DIR") {
         Some(dir) => PathBuf::from(dir),
@@ -57,39 +58,51 @@ fn cache_file_path() -> Option<PathBuf> {
             PathBuf::from(home).join(".longbridge").join("cache")
         }
     };
-    Some(dir.join("counter-ids.json"))
+    Some(dir.join("counter-ids.csv"))
 }
 
-fn cached_counter_ids() -> &'static RwLock<HashMap<String, String>> {
+fn cached_counter_ids() -> &'static RwLock<HashSet<String>> {
     CACHED_COUNTER_IDS.get_or_init(|| {
-        let map = cache_file_path()
+        let set = cache_file_path()
             .and_then(|path| std::fs::read_to_string(path).ok())
-            .and_then(|s| serde_json::from_str(&s).ok())
+            .map(|s| {
+                s.lines()
+                    .map(str::trim)
+                    .filter(|line| !line.is_empty())
+                    .map(ToString::to_string)
+                    .collect()
+            })
             .unwrap_or_default();
-        RwLock::new(map)
+        RwLock::new(set)
     })
 }
 
-/// Merge remotely resolved `symbol → counter_id` entries into the local cache
-/// (in memory and on disk), so subsequent [`symbol_to_counter_id`] /
-/// [`lookup_counter_id`] calls resolve them without another network round
-/// trip.
-pub fn cache_counter_ids(entries: &HashMap<String, String>) {
-    if entries.is_empty() {
-        return;
-    }
-    let mut map = match cached_counter_ids().write() {
+/// Merge remotely resolved counter IDs into the local cache (in memory and
+/// on disk), so subsequent [`symbol_to_counter_id`] / [`lookup_counter_id`]
+/// calls resolve them without another network round trip.
+pub fn cache_counter_ids<'a>(counter_ids: impl IntoIterator<Item = &'a str>) {
+    let mut set = match cached_counter_ids().write() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    for (symbol, counter_id) in entries {
-        map.insert(symbol.to_uppercase(), counter_id.clone());
+    let before = set.len();
+    set.extend(
+        counter_ids
+            .into_iter()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(ToString::to_string),
+    );
+    if set.len() == before {
+        return;
     }
-    if let (Some(path), Ok(json)) = (cache_file_path(), serde_json::to_string(&*map)) {
+    if let Some(path) = cache_file_path() {
         if let Some(parent) = path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
-        let _ = std::fs::write(path, json);
+        let mut lines: Vec<&str> = set.iter().map(String::as_str).collect();
+        lines.sort_unstable();
+        let _ = std::fs::write(path, lines.join("\n") + "\n");
     }
 }
 
@@ -119,7 +132,13 @@ pub fn lookup_counter_id(symbol: &str) -> Option<String> {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    cached.get(&format!("{code}.{market}")).cloned()
+    for prefix in &["ETF", "IX", "WT", "ST"] {
+        let candidate = format!("{prefix}/{market}/{code}");
+        if cached.contains(candidate.as_str()) {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 /// Convert a user-supplied symbol (e.g. `TSLA.US`, `700.HK`, `.DJI.US`,
@@ -323,18 +342,22 @@ mod tests {
         assert_eq!(lookup_counter_id("FAKE9.US"), None);
         assert_eq!(symbol_to_counter_id("FAKE9.US"), "ST/US/FAKE9");
 
-        // After caching a remote-resolved entry, lookups return it
-        let entries = HashMap::from([("FAKE9.US".to_string(), "ETF/US/FAKE9".to_string())]);
-        cache_counter_ids(&entries);
+        // After caching remote-resolved entries, lookups return them —
+        // including backend-confirmed ST/ entries
+        cache_counter_ids(["ETF/US/FAKE9", "ST/US/FAKE8"]);
         assert_eq!(
             lookup_counter_id("FAKE9.US").as_deref(),
             Some("ETF/US/FAKE9")
         );
         assert_eq!(symbol_to_counter_id("FAKE9.US"), "ETF/US/FAKE9");
+        assert_eq!(
+            lookup_counter_id("FAKE8.US").as_deref(),
+            Some("ST/US/FAKE8")
+        );
 
-        // Persisted to disk
-        let saved = std::fs::read_to_string(dir.join("counter-ids.json")).unwrap();
-        assert!(saved.contains("ETF/US/FAKE9"));
+        // Persisted to disk as one counter_id per line
+        let saved = std::fs::read_to_string(dir.join("counter-ids.csv")).unwrap();
+        assert_eq!(saved, "ETF/US/FAKE9\nST/US/FAKE8\n");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/rust/src/utils/counter.rs
+++ b/rust/src/utils/counter.rs
@@ -5,8 +5,16 @@
 //! `WT/HK/10005`. These helpers convert between user-facing symbols
 //! (e.g. `TSLA.US`, `700.HK`, `.DJI.US`) and counter IDs, using an
 //! embedded ETF + index + warrant directory to pick the right prefix.
+//!
+//! The embedded directory may lag behind newly listed instruments. Entries
+//! resolved remotely (see `QuoteContext::resolve_counter_ids`) are persisted
+//! to a local cache file and consulted on subsequent lookups.
 
-use std::{collections::HashSet, sync::OnceLock};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::{OnceLock, RwLock},
+};
 
 static SPECIAL_COUNTER_IDS: OnceLock<HashSet<&'static str>> = OnceLock::new();
 
@@ -25,22 +33,109 @@ fn special_counter_ids() -> &'static HashSet<&'static str> {
     })
 }
 
+// ── remote-resolved counter_id cache ──────────────────────────────
+
+static CACHED_COUNTER_IDS: OnceLock<RwLock<HashMap<String, String>>> = OnceLock::new();
+
+#[cfg(test)]
+static TEST_CACHE_DIR: OnceLock<PathBuf> = OnceLock::new();
+
+/// Cache file path: `$LONGBRIDGE_CACHE_DIR/counter-ids.json`, defaulting to
+/// `~/.longbridge/cache/counter-ids.json`.
+fn cache_file_path() -> Option<PathBuf> {
+    #[cfg(test)]
+    if let Some(dir) = TEST_CACHE_DIR.get() {
+        return Some(dir.join("counter-ids.json"));
+    }
+    let dir = match std::env::var_os("LONGBRIDGE_CACHE_DIR") {
+        Some(dir) => PathBuf::from(dir),
+        None => {
+            #[cfg(windows)]
+            let home = std::env::var_os("USERPROFILE")?;
+            #[cfg(not(windows))]
+            let home = std::env::var_os("HOME")?;
+            PathBuf::from(home).join(".longbridge").join("cache")
+        }
+    };
+    Some(dir.join("counter-ids.json"))
+}
+
+fn cached_counter_ids() -> &'static RwLock<HashMap<String, String>> {
+    CACHED_COUNTER_IDS.get_or_init(|| {
+        let map = cache_file_path()
+            .and_then(|path| std::fs::read_to_string(path).ok())
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default();
+        RwLock::new(map)
+    })
+}
+
+/// Merge remotely resolved `symbol → counter_id` entries into the local cache
+/// (in memory and on disk), so subsequent [`symbol_to_counter_id`] /
+/// [`lookup_counter_id`] calls resolve them without another network round
+/// trip.
+pub fn cache_counter_ids(entries: &HashMap<String, String>) {
+    if entries.is_empty() {
+        return;
+    }
+    let mut map = match cached_counter_ids().write() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    for (symbol, counter_id) in entries {
+        map.insert(symbol.to_uppercase(), counter_id.clone());
+    }
+    if let (Some(path), Ok(json)) = (cache_file_path(), serde_json::to_string(&*map)) {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(path, json);
+    }
+}
+
+/// Look up a symbol in the local directory only (embedded special set, the
+/// remote-resolved cache, and leading-dot index notation). Returns `None`
+/// when the symbol is unknown locally — i.e. [`symbol_to_counter_id`] would
+/// fall back to the default `ST/` prefix, which may be wrong for newly
+/// listed ETFs / indexes / warrants.
+pub fn lookup_counter_id(symbol: &str) -> Option<String> {
+    let (code, market) = symbol.rsplit_once('.')?;
+    let market = market.to_uppercase();
+    if code.starts_with('.') {
+        return Some(format!("IX/{market}/{code}"));
+    }
+    let code = if market == "HK" && code.chars().all(|c| c.is_ascii_digit()) {
+        code.trim_start_matches('0')
+    } else {
+        code
+    };
+    for prefix in &["ETF", "IX", "WT"] {
+        let candidate = format!("{prefix}/{market}/{code}");
+        if special_counter_ids().contains(candidate.as_str()) {
+            return Some(candidate);
+        }
+    }
+    let cached = match cached_counter_ids().read() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    cached.get(&format!("{code}.{market}")).cloned()
+}
+
 /// Convert a user-supplied symbol (e.g. `TSLA.US`, `700.HK`, `.DJI.US`,
 /// `HSI.HK`) to a counter_id (e.g. `ST/US/TSLA`, `ST/HK/700`, `IX/US/.DJI`,
 /// `IX/HK/HSI`).
 ///
 /// Leading-dot symbols (e.g. `.DJI.US`) are US market indexes and always map
 /// to `IX/`. All other symbols are checked against the embedded
-/// ETF + index + warrant set; a matching entry is returned as-is. Unmatched
-/// symbols default to `ST/`.
+/// ETF + index + warrant set and the remote-resolved cache; a matching entry
+/// is returned as-is. Unmatched symbols default to `ST/`.
 pub fn symbol_to_counter_id(symbol: &str) -> String {
     if let Some((code, market)) = symbol.rsplit_once('.') {
-        let market = market.to_uppercase();
-        // Leading-dot symbols are US market indexes; the dot is part of the
-        // counter_id (e.g. `.DJI.US` → `IX/US/.DJI`)
-        if code.starts_with('.') {
-            return format!("IX/{market}/{code}");
+        if let Some(counter_id) = lookup_counter_id(symbol) {
+            return counter_id;
         }
+        let market = market.to_uppercase();
         // Strip leading zeros from numeric HK codes (e.g. `00700` → `700`).
         // Other markets keep their codes verbatim (A-share codes such as
         // `000001.SZ` have significant leading zeros).
@@ -49,13 +144,6 @@ pub fn symbol_to_counter_id(symbol: &str) -> String {
         } else {
             code
         };
-        // Check special counter_ids set (ETF, IX, and WT entries)
-        for prefix in &["ETF", "IX", "WT"] {
-            let candidate = format!("{prefix}/{market}/{code}");
-            if special_counter_ids().contains(candidate.as_str()) {
-                return candidate;
-            }
-        }
         format!("ST/{market}/{code}")
     } else {
         symbol.to_string()
@@ -223,5 +311,39 @@ mod tests {
     fn roundtrip() {
         let cid = symbol_to_counter_id("TSLA.US");
         assert_eq!(counter_id_to_symbol(&cid), "TSLA.US");
+    }
+
+    #[test]
+    fn cached_counter_ids_roundtrip() {
+        let dir = std::env::temp_dir().join("lb-counter-cache-test");
+        // Redirect the cache file away from the real user cache directory.
+        let dir = TEST_CACHE_DIR.get_or_init(|| dir).clone();
+
+        // Unknown symbol falls back to ST/ before caching
+        assert_eq!(lookup_counter_id("FAKE9.US"), None);
+        assert_eq!(symbol_to_counter_id("FAKE9.US"), "ST/US/FAKE9");
+
+        // After caching a remote-resolved entry, lookups return it
+        let entries = HashMap::from([("FAKE9.US".to_string(), "ETF/US/FAKE9".to_string())]);
+        cache_counter_ids(&entries);
+        assert_eq!(
+            lookup_counter_id("FAKE9.US").as_deref(),
+            Some("ETF/US/FAKE9")
+        );
+        assert_eq!(symbol_to_counter_id("FAKE9.US"), "ETF/US/FAKE9");
+
+        // Persisted to disk
+        let saved = std::fs::read_to_string(dir.join("counter-ids.json")).unwrap();
+        assert!(saved.contains("ETF/US/FAKE9"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn lookup_known_special() {
+        assert_eq!(lookup_counter_id("QQQ.US").as_deref(), Some("ETF/US/QQQ"));
+        assert_eq!(lookup_counter_id("HSI.HK").as_deref(), Some("IX/HK/HSI"));
+        assert_eq!(lookup_counter_id(".DJI.US").as_deref(), Some("IX/US/.DJI"));
+        assert_eq!(lookup_counter_id("TSLA.US"), None);
+        assert_eq!(lookup_counter_id("NODOT"), None);
     }
 }


### PR DESCRIPTION
## Summary

- **`QuoteContext::symbol_to_counter_ids(symbols)`** — batch symbol → counter_id conversion via the new `POST /v1/quote/symbol-to-counter-ids` endpoint (request `{ticker_regions: [\"TSLA.US\", \"700.HK\"]}`, response `{list: {symbol: counter_id}}`; unrecognized symbols are omitted)
- **`QuoteContext::resolve_counter_ids(symbols)`** — local-first resolution: embedded ETF/IX/WT directory + resolved-cache hits are answered without network; remaining symbols are resolved in one batch remotely, persisted to **`~/.longbridge/cache/counter-ids.csv`** (one counter_id per line, same format as the embedded directory files; directory overridable via `LONGBRIDGE_CACHE_DIR`), and answered from cache afterwards. Backend-unrecognized symbols fall back to the default `ST/` conversion (and are not cached)
- The cache is a counter_id set; lookups match `ETF/IX/WT/ST` prefix candidates against it — backend-confirmed `ST/` entries are cached too, so repeat resolutions of plain stocks also skip the network
- `counter` module gains `lookup_counter_id` / `cache_counter_ids`; `symbol_to_counter_id` now also consults the resolved cache — so newly listed instruments missing from the embedded directory (the DRAM.US class of problem) resolve correctly after the first remote query
- Blocking wrappers on `QuoteContextSync`; Rust only for now (bindings to follow as needed)

## Verification

- `cargo test -p longbridge --lib utils::counter`: 24 passed (incl. CSV cache roundtrip + local lookup tests)
- `cargo clippy --all --all-features`: clean
- Live against staging: `resolve_counter_ids([\"DRAM.US\", \"TSLA.US\", \"QQQ.US\", \"NEWFAKE.US\"])` → DRAM/QQQ resolved locally, TSLA resolved remotely **and persisted to the cache file**, NEWFAKE fell back to `ST/US/NEWFAKE` without being cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)