### PR TITLE
chore: release 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.3.0]
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["rust", "python", "nodejs", "java", "c"]
 
 [workspace.package]
-version = "4.2.2"
+version = "4.3.0"
 edition = "2024"
 
 [profile.release]


### PR DESCRIPTION
## Summary

Bump version to `4.3.0` and promote `[Unreleased]` CHANGELOG to `[4.3.0]`.

## Changes in 4.3.0

### Added

- **All languages:** `FundamentalContext` gains `etf_asset_allocation(symbol)` — queries `GET /v1/quote/etf-asset-allocation` for ETF asset allocation grouped by element type (`Holdings` / `Regional` / `AssetClass` / `Industry`)
- **Rust:** new public `longbridge::counter` module — `symbol_to_counter_id`, `index_symbol_to_counter_id`, `counter_id_to_symbol`, and `is_etf`
- **Rust:** `QuoteContext` gains `symbol_to_counter_ids(symbols)` and `resolve_counter_ids(symbols)`

### Changed

- `symbol_to_counter_id` now also consults the embedded index and warrant directories

### Fixed

- Refreshed the embedded US ETF list (4574 → 7250 entries) and added index (648) + warrant (17693) directories