### PR TITLE
fix(ci): replace msbuild longbridge.sln with cmake --build for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,9 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Install cargo make
-        run: cargo install cargo-make
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-make
 
       - name: Check with clippy
         run: cargo clippy -p longbridge-c --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,9 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Install cargo make
-        run: cargo install cargo-make
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-make
 
       - name: Build
         if: ${{ matrix.settings.target != 'aarch64-apple-darwin' }}
@@ -348,7 +350,9 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Install cargo make
-        run: cargo install cargo-make
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-make
 
       - name: Build
         if: ${{ matrix.settings.target != 'aarch64-apple-darwin' }}

--- a/c/Makefile.toml
+++ b/c/Makefile.toml
@@ -9,13 +9,13 @@ args = ["cargo-build_longbridge_c"]
 cwd = "cmake.build"
 
 [tasks.c.windows]
-command = "msbuild"
-args = ["longbridge.sln", "-p:Configuration=Debug", "/t:cargo-build_longbridge_c"]
+command = "cmake"
+args = ["--build", ".", "--config", "Debug", "--target", "cargo-build_longbridge_c"]
 cwd = "cmake.build"
 
 [tasks.c-release.windows]
-command = "msbuild"
-args = ["longbridge.sln", "-p:Configuration=Release", "/t:cargo-build_longbridge_c"]
+command = "cmake"
+args = ["--build", ".", "--config", "Release", "--target", "cargo-build_longbridge_c"]
 cwd = "cmake.build"
 
 [tasks.c-test]
@@ -24,6 +24,6 @@ args = ["test-c"]
 cwd = "cmake.build"
 
 [tasks.c-test.windows]
-command = "msbuild"
-args = ["longbridge.sln", "-p:Configuration=Debug", "/t:test-c"]
+command = "cmake"
+args = ["--build", ".", "--config", "Debug", "--target", "test-c"]
 cwd = "cmake.build"

--- a/cpp/Makefile.toml
+++ b/cpp/Makefile.toml
@@ -9,13 +9,13 @@ args = ["longbridge_cpp"]
 cwd = "cmake.build"
 
 [tasks.cpp.windows]
-command = "msbuild"
-args = ["longbridge.sln", "-p:Configuration=Debug", "/t:longbridge_cpp"]
+command = "cmake"
+args = ["--build", ".", "--config", "Debug", "--target", "longbridge_cpp"]
 cwd = "cmake.build"
 
 [tasks.cpp-release.windows]
-command = "msbuild"
-args = ["longbridge.sln", "-p:Configuration=Release", "/t:longbridge_cpp"]
+command = "cmake"
+args = ["--build", ".", "--config", "Release", "--target", "longbridge_cpp"]
 cwd = "cmake.build"
 
 [tasks.cpp-test]
@@ -24,6 +24,6 @@ args = ["test-cpp"]
 cwd = "cmake.build"
 
 [tasks.cpp-test.windows]
-command = "msbuild"
-args = ["longbridge.sln", "-p:Configuration=Debug", "/t:test-cpp"]
+command = "cmake"
+args = ["--build", ".", "--config", "Debug", "--target", "test-cpp"]
 cwd = "cmake.build"


### PR DESCRIPTION
## Problem

`windows-latest` runner was upgraded to VS2026 (MSBuild 18.6.3), which generates a different `.sln` filename than VS2022. The Makefile.toml had `longbridge.sln` hardcoded, causing:

```
MSBUILD : error MSB1009: Project file does not exist.
Switch: longbridge.sln
```

## Fix

Replace `msbuild longbridge.sln` with `cmake --build .` in `c/Makefile.toml` and `cpp/Makefile.toml`. `cmake --build` delegates to the underlying build system and doesn't depend on the `.sln` filename.

**Before:**
```toml
[tasks.c.windows]
command = "msbuild"
args = ["longbridge.sln", "-p:Configuration=Debug", "/t:cargo-build_longbridge_c"]
```

**After:**
```toml
[tasks.c.windows]
command = "cmake"
args = ["--build", ".", "--config", "Debug", "--target", "cargo-build_longbridge_c"]
```

This change is backward-compatible with VS2022 and works with any cmake generator.