### PR TITLE
chore: release 4.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,9 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Install cargo make
-        run: cargo install cargo-make
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-make
 
       - name: Check with clippy
         run: cargo clippy -p longbridge-c --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,9 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Install cargo make
-        run: cargo install cargo-make
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-make
 
       - name: Build
         if: ${{ matrix.settings.target != 'aarch64-apple-darwin' }}
@@ -348,7 +350,9 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Install cargo make
-        run: cargo install cargo-make
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-make
 
       - name: Build
         if: ${{ matrix.settings.target != 'aarch64-apple-darwin' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.1] - 2026-06-12
+
+### Added
+
+- **All languages:** `FundamentalContext` gains `macroeconomic_indicators(country, offset, limit)` — list macroeconomic indicators via `GET /v1/quote/macrodata`; filter by country (`MacroeconomicCountry::HongKong / China / UnitedStates / EuroZone / Japan / Singapore`); response includes `count` (total matching)
+- **All languages:** `FundamentalContext` gains `macroeconomic(indicator_code, start_date, end_date, offset, limit)` — historical data for a specific indicator via `GET /v1/quote/macrodata/{indicator_code}`; `start_date` / `end_date` accept `"YYYY-MM-DD"` strings; response includes `count` (total data points)
+- New types: `MultiLanguageText`, `MacroeconomicCountry`, `MacroeconomicImportance`, `MacroeconomicIndicator`, `MacroeconomicIndicatorListResponse`, `Macroeconomic`, `MacroeconomicResponse`
+
+### Fixed
+
+- `MacroeconomicIndicator.describe` / `name` / `MacroeconomicResponse.info`: handle `null` responses from API without deserializing error
+
 ## [4.3.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["rust", "python", "nodejs", "java", "c"]
 
 [workspace.package]
-version = "4.3.0"
+version = "4.3.1"
 edition = "2024"
 
 [profile.release]

--- a/c/Makefile.toml
+++ b/c/Makefile.toml
@@ -9,13 +9,13 @@ args = ["cargo-build_longbridge_c"]
 cwd = "cmake.build"
 
 [tasks.c.windows]
-command = "msbuild"
-args = ["longbridge.sln", "-p:Configuration=Debug", "/t:cargo-build_longbridge_c"]
+command = "cmake"
+args = ["--build", ".", "--config", "Debug", "--target", "cargo-build_longbridge_c"]
 cwd = "cmake.build"
 
 [tasks.c-release.windows]
-command = "msbuild"
-args = ["longbridge.sln", "-p:Configuration=Release", "/t:cargo-build_longbridge_c"]
+command = "cmake"
+args = ["--build", ".", "--config", "Release", "--target", "cargo-build_longbridge_c"]
 cwd = "cmake.build"
 
 [tasks.c-test]
@@ -24,6 +24,6 @@ args = ["test-c"]
 cwd = "cmake.build"
 
 [tasks.c-test.windows]
-command = "msbuild"
-args = ["longbridge.sln", "-p:Configuration=Debug", "/t:test-c"]
+command = "cmake"
+args = ["--build", ".", "--config", "Debug", "--target", "test-c"]
 cwd = "cmake.build"

--- a/cpp/Makefile.toml
+++ b/cpp/Makefile.toml
@@ -9,13 +9,13 @@ args = ["longbridge_cpp"]
 cwd = "cmake.build"
 
 [tasks.cpp.windows]
-command = "msbuild"
-args = ["longbridge.sln", "-p:Configuration=Debug", "/t:longbridge_cpp"]
+command = "cmake"
+args = ["--build", ".", "--config", "Debug", "--target", "longbridge_cpp"]
 cwd = "cmake.build"
 
 [tasks.cpp-release.windows]
-command = "msbuild"
-args = ["longbridge.sln", "-p:Configuration=Release", "/t:longbridge_cpp"]
+command = "cmake"
+args = ["--build", ".", "--config", "Release", "--target", "longbridge_cpp"]
 cwd = "cmake.build"
 
 [tasks.cpp-test]
@@ -24,6 +24,6 @@ args = ["test-cpp"]
 cwd = "cmake.build"
 
 [tasks.cpp-test.windows]
-command = "msbuild"
-args = ["longbridge.sln", "-p:Configuration=Debug", "/t:test-cpp"]
+command = "cmake"
+args = ["--build", ".", "--config", "Debug", "--target", "test-cpp"]
 cwd = "cmake.build"

--- a/java/javasrc/src/main/java/com/longbridge/SdkNative.java
+++ b/java/javasrc/src/main/java/com/longbridge/SdkNative.java
@@ -451,6 +451,14 @@ public class SdkNative {
                         Object opts,
                         AsyncCallback callback);
 
+        public static native void fundamentalContextMacroeconomicIndicators(long context,
+                        Object country, Object offset, Object limit,
+                        AsyncCallback callback);
+
+        public static native void fundamentalContextMacroeconomic(long context,
+                        Object indicatorCode, Object startTime, Object endTime, Object offset, Object limit,
+                        AsyncCallback callback);
+
         public static native void portfolioContextProfitAnalysisFlows(long context, Object opts,
                         AsyncCallback callback);
 

--- a/java/javasrc/src/main/java/com/longbridge/fundamental/FundamentalContext.java
+++ b/java/javasrc/src/main/java/com/longbridge/fundamental/FundamentalContext.java
@@ -334,4 +334,24 @@ public class FundamentalContext implements AutoCloseable {
             SdkNative.fundamentalContextValuationComparison(raw, opts, callback);
         });
     }
+
+    /**
+     * List macroeconomic indicators.
+     * country: ISO country code string (e.g. "US", "CN", "EU"); pass null for all countries.
+     */
+    public CompletableFuture<MacroeconomicIndicatorListResponse> getMacroeconomicIndicators(String country, Integer offset, Integer limit) throws OpenApiException {
+        return AsyncCallback.executeTask((callback) -> {
+            SdkNative.fundamentalContextMacroeconomicIndicators(raw, country, offset, limit, callback);
+        });
+    }
+
+    /**
+     * Get historical data for a macroeconomic indicator.
+     * startDate and endDate are date strings in "YYYY-MM-DD" format.
+     */
+    public CompletableFuture<MacroeconomicResponse> getMacroeconomic(String indicatorCode, String startDate, String endDate, Integer offset, Integer limit) throws OpenApiException {
+        return AsyncCallback.executeTask((callback) -> {
+            SdkNative.fundamentalContextMacroeconomic(raw, indicatorCode, startDate, endDate, offset, limit, callback);
+        });
+    }
 }

--- a/java/javasrc/src/main/java/com/longbridge/fundamental/Macroeconomic.java
+++ b/java/javasrc/src/main/java/com/longbridge/fundamental/Macroeconomic.java
@@ -1,0 +1,15 @@
+package com.longbridge.fundamental;
+
+/** One historical data point for a macroeconomic indicator. */
+public class Macroeconomic {
+    /** Statistical period (e.g. 2024-Q1, 2024-03). */
+    public String period;
+    public String releaseAt;
+    public String actualValue;
+    public String previousValue;
+    public String forecastValue;
+    public String revisedValue;
+    public String nextReleaseAt;
+    public MultiLanguageText unit;
+    public MultiLanguageText unitPrefix;
+}

--- a/java/javasrc/src/main/java/com/longbridge/fundamental/MacroeconomicIndicator.java
+++ b/java/javasrc/src/main/java/com/longbridge/fundamental/MacroeconomicIndicator.java
@@ -1,0 +1,19 @@
+package com.longbridge.fundamental;
+
+/** Metadata for one macroeconomic indicator. */
+public class MacroeconomicIndicator {
+    /** External vendor code (input to getEconomicIndicator). */
+    public String indicatorCode;
+    public String sourceOrg;
+    public String country;
+    public MultiLanguageText name;
+    public String adjustmentFactor;
+    /** Release periodicity (e.g. monthly / quarterly). */
+    public String periodicity;
+    public String category;
+    public MultiLanguageText describe;
+    /** Importance — higher is more important. */
+    public int importance;
+    /** Start date of data coverage (unix timestamp string). */
+    public String startDate;
+}

--- a/java/javasrc/src/main/java/com/longbridge/fundamental/MacroeconomicIndicatorListResponse.java
+++ b/java/javasrc/src/main/java/com/longbridge/fundamental/MacroeconomicIndicatorListResponse.java
@@ -1,0 +1,8 @@
+package com.longbridge.fundamental;
+
+/** Response for {@link FundamentalContext#getMacroeconomicIndicators}. */
+public class MacroeconomicIndicatorListResponse {
+    public MacroeconomicIndicator[] data;
+    /** Total number of indicators matching the query. */
+    public int count;
+}

--- a/java/javasrc/src/main/java/com/longbridge/fundamental/MacroeconomicResponse.java
+++ b/java/javasrc/src/main/java/com/longbridge/fundamental/MacroeconomicResponse.java
@@ -1,0 +1,9 @@
+package com.longbridge.fundamental;
+
+/** Response for {@link FundamentalContext#getMacroeconomic}. */
+public class MacroeconomicResponse {
+    public MacroeconomicIndicator info;
+    public Macroeconomic[] data;
+    /** Total number of historical data points. */
+    public int count;
+}

--- a/java/javasrc/src/main/java/com/longbridge/fundamental/MultiLanguageText.java
+++ b/java/javasrc/src/main/java/com/longbridge/fundamental/MultiLanguageText.java
@@ -1,0 +1,8 @@
+package com.longbridge.fundamental;
+
+/** Localized text in simplified Chinese, traditional Chinese, and English. */
+public class MultiLanguageText {
+    public String english;
+    public String simplifiedChinese;
+    public String traditionalChinese;
+}

--- a/java/src/fundamental_context.rs
+++ b/java/src/fundamental_context.rs
@@ -262,3 +262,69 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_fundamentalContextVa
         Ok(())
     })
 }
+
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn Java_com_longbridge_SdkNative_fundamentalContextMacroeconomicIndicators(
+    mut env: JNIEnv,
+    _class: JClass,
+    context: i64,
+    country: JObject,
+    offset: JObject,
+    limit: JObject,
+    callback: JObject,
+) {
+    jni_result(&mut env, (), |env| {
+        let context = &*(context as *const ContextObj);
+        let country: Option<String> = FromJValue::from_jvalue(env, country.into())?;
+        let country = country.and_then(|s| {
+            use longbridge::fundamental::MacroeconomicCountry::*;
+            match s.as_str() {
+                "HK" | "Hong Kong SAR China" => Some(HongKong),
+                "CN" | "China (Mainland)" => Some(China),
+                "US" | "United States" => Some(UnitedStates),
+                "EU" | "Euro Zone" => Some(EuroZone),
+                "JP" | "Japan" => Some(Japan),
+                "SG" | "Singapore" => Some(Singapore),
+                _ => None,
+            }
+        });
+        let offset: Option<i32> = FromJValue::from_jvalue(env, offset.into())?;
+        let limit: Option<i32> = FromJValue::from_jvalue(env, limit.into())?;
+        async_util::execute(env, callback, async move {
+            Ok(context
+                .ctx
+                .macroeconomic_indicators(country, offset, limit)
+                .await?)
+        })?;
+        Ok(())
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn Java_com_longbridge_SdkNative_fundamentalContextMacroeconomic(
+    mut env: JNIEnv,
+    _class: JClass,
+    context: i64,
+    indicator_code: JObject,
+    start_time: JObject,
+    end_time: JObject,
+    offset: JObject,
+    limit: JObject,
+    callback: JObject,
+) {
+    jni_result(&mut env, (), |env| {
+        let context = &*(context as *const ContextObj);
+        let indicator_code: String = FromJValue::from_jvalue(env, indicator_code.into())?;
+        let start_date: Option<String> = FromJValue::from_jvalue(env, start_time.into())?;
+        let end_date: Option<String> = FromJValue::from_jvalue(env, end_time.into())?;
+        let offset: Option<i32> = FromJValue::from_jvalue(env, offset.into())?;
+        let limit: Option<i32> = FromJValue::from_jvalue(env, limit.into())?;
+        async_util::execute(env, callback, async move {
+            Ok(context
+                .ctx
+                .macroeconomic(indicator_code, start_date, end_date, offset, limit)
+                .await?)
+        })?;
+        Ok(())
+    })
+}

--- a/java/src/types/classes.rs
+++ b/java/src/types/classes.rs
@@ -2698,6 +2698,66 @@ impl_java_class!(
     ]
 );
 
+impl_java_class!(
+    "com/longbridge/fundamental/MultiLanguageText",
+    longbridge::fundamental::MultiLanguageText,
+    [english, simplified_chinese, traditional_chinese]
+);
+
+impl_java_class!(
+    "com/longbridge/fundamental/MacroeconomicIndicator",
+    longbridge::fundamental::MacroeconomicIndicator,
+    [
+        indicator_code,
+        source_org,
+        country,
+        name,
+        adjustment_factor,
+        periodicity,
+        category,
+        describe,
+        importance,
+        start_date
+    ]
+);
+
+impl_java_class!(
+    "com/longbridge/fundamental/Macroeconomic",
+    longbridge::fundamental::Macroeconomic,
+    [
+        period,
+        release_at,
+        actual_value,
+        previous_value,
+        forecast_value,
+        revised_value,
+        next_release_at,
+        unit,
+        unit_prefix
+    ]
+);
+
+impl_java_class!(
+    "com/longbridge/fundamental/MacroeconomicIndicatorListResponse",
+    longbridge::fundamental::MacroeconomicIndicatorListResponse,
+    [
+        #[java(objarray)]
+        data,
+        count
+    ]
+);
+
+impl_java_class!(
+    "com/longbridge/fundamental/MacroeconomicResponse",
+    longbridge::fundamental::MacroeconomicResponse,
+    [
+        info,
+        #[java(objarray)]
+        data,
+        count
+    ]
+);
+
 // ── MarketContext: top movers / rank ──────────────────────────────
 
 impl_java_class!(

--- a/nodejs/index.d.ts
+++ b/nodejs/index.d.ts
@@ -618,6 +618,10 @@ export declare class FundamentalContext {
    * industry)
    */
   etfAssetAllocation(symbol: string): Promise<AssetAllocationResponse>
+  /** List macroeconomic indicators */
+  macroeconomicIndicators(country?: MacroeconomicCountry | undefined | null, offset?: number | undefined | null, limit?: number | undefined | null): Promise<MacroeconomicIndicatorListResponse>
+  /** Get historical data for a macroeconomic indicator */
+  macroeconomic(indicatorCode: string, startDate?: string | undefined | null, endDate?: string | undefined | null, offset?: number | undefined | null, limit?: number | undefined | null): Promise<MacroeconomicResponse>
 }
 
 /** Fund position */
@@ -4473,6 +4477,65 @@ export declare const enum Language {
   EN = 2
 }
 
+/** One historical data point for a macroeconomic indicator */
+export interface Macroeconomic {
+  period: string
+  /** Release datetime (unix timestamp in seconds; null if unset) */
+  releaseAt?: number
+  actualValue: string
+  previousValue: string
+  forecastValue: string
+  revisedValue: string
+  /** Next release datetime (unix timestamp in seconds; null if unset) */
+  nextReleaseAt?: number
+  unit: MultiLanguageText
+  unitPrefix: MultiLanguageText
+}
+
+/** Country code for filtering macroeconomic indicators */
+export declare const enum MacroeconomicCountry {
+  /** Hong Kong SAR China */
+  HongKong = 0,
+  /** China (Mainland) */
+  China = 1,
+  /** United States */
+  UnitedStates = 2,
+  /** Euro Zone */
+  EuroZone = 3,
+  /** Japan */
+  Japan = 4,
+  /** Singapore */
+  Singapore = 5
+}
+
+/** Metadata for one macroeconomic indicator */
+export interface MacroeconomicIndicator {
+  indicatorCode: string
+  sourceOrg: string
+  country: string
+  name: MultiLanguageText
+  adjustmentFactor: string
+  periodicity: string
+  category: string
+  describe: MultiLanguageText
+  importance: number
+  /** Start date of data coverage (unix timestamp in seconds; null if unset) */
+  startDate?: number
+}
+
+/** Response for macroeconomic_indicators */
+export interface MacroeconomicIndicatorListResponse {
+  data: Array<MacroeconomicIndicator>
+  count: number
+}
+
+/** Response for macroeconomic */
+export interface MacroeconomicResponse {
+  info: MacroeconomicIndicator
+  data: Array<Macroeconomic>
+  count: number
+}
+
 export declare const enum Market {
   /** Unknown */
   Unknown = 0,
@@ -4513,6 +4576,13 @@ export interface MarketTimeItem {
   subStatus: number
   /** Delayed-quote sub-status code */
   delaySubStatus: number
+}
+
+/** Localized text in simplified Chinese, traditional Chinese, and English */
+export interface MultiLanguageText {
+  english: string
+  simplifiedChinese: string
+  traditionalChinese: string
 }
 
 /** Options for listing topics created by the current authenticated user */

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -689,6 +689,7 @@ module.exports.FlowDirection = nativeBinding.FlowDirection
 module.exports.Granularity = nativeBinding.Granularity
 module.exports.InstitutionRecommend = nativeBinding.InstitutionRecommend
 module.exports.Language = nativeBinding.Language
+module.exports.MacrodataCountry = nativeBinding.MacrodataCountry
 module.exports.Market = nativeBinding.Market
 module.exports.OptionDirection = nativeBinding.OptionDirection
 module.exports.OptionType = nativeBinding.OptionType

--- a/nodejs/src/fundamental/context.rs
+++ b/nodejs/src/fundamental/context.rs
@@ -287,4 +287,38 @@ impl FundamentalContext {
             .map_err(ErrorNewType)?
             .into())
     }
+
+    /// List macroeconomic indicators
+    #[napi]
+    pub async fn macroeconomic_indicators(
+        &self,
+        country: Option<MacroeconomicCountry>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> Result<MacroeconomicIndicatorListResponse> {
+        Ok(self
+            .ctx
+            .macroeconomic_indicators(country.map(Into::into), offset, limit)
+            .await
+            .map_err(ErrorNewType)?
+            .into())
+    }
+
+    /// Get historical data for a macroeconomic indicator
+    #[napi]
+    pub async fn macroeconomic(
+        &self,
+        indicator_code: String,
+        start_date: Option<String>,
+        end_date: Option<String>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> Result<MacroeconomicResponse> {
+        Ok(self
+            .ctx
+            .macroeconomic(indicator_code, start_date, end_date, offset, limit)
+            .await
+            .map_err(ErrorNewType)?
+            .into())
+    }
 }

--- a/nodejs/src/fundamental/types.rs
+++ b/nodejs/src/fundamental/types.rs
@@ -1902,3 +1902,158 @@ impl From<lb::AssetAllocationResponse> for AssetAllocationResponse {
         }
     }
 }
+
+// ── economic_indicator ─────────────────────────────────────────────────────
+
+/// Localized text in simplified Chinese, traditional Chinese, and English
+#[napi_derive::napi(object)]
+#[derive(Debug, Clone, Default)]
+pub struct MultiLanguageText {
+    pub english: String,
+    pub simplified_chinese: String,
+    pub traditional_chinese: String,
+}
+
+impl From<lb::MultiLanguageText> for MultiLanguageText {
+    fn from(v: lb::MultiLanguageText) -> Self {
+        Self {
+            english: v.english,
+            simplified_chinese: v.simplified_chinese,
+            traditional_chinese: v.traditional_chinese,
+        }
+    }
+}
+
+/// Country code for filtering macroeconomic indicators
+#[napi_derive::napi]
+#[derive(Debug, Copy, Clone)]
+pub enum MacroeconomicCountry {
+    /// Hong Kong SAR China
+    HongKong,
+    /// China (Mainland)
+    China,
+    /// United States
+    UnitedStates,
+    /// Euro Zone
+    EuroZone,
+    /// Japan
+    Japan,
+    /// Singapore
+    Singapore,
+}
+
+impl From<MacroeconomicCountry> for lb::MacroeconomicCountry {
+    fn from(v: MacroeconomicCountry) -> Self {
+        match v {
+            MacroeconomicCountry::HongKong => lb::MacroeconomicCountry::HongKong,
+            MacroeconomicCountry::China => lb::MacroeconomicCountry::China,
+            MacroeconomicCountry::UnitedStates => lb::MacroeconomicCountry::UnitedStates,
+            MacroeconomicCountry::EuroZone => lb::MacroeconomicCountry::EuroZone,
+            MacroeconomicCountry::Japan => lb::MacroeconomicCountry::Japan,
+            MacroeconomicCountry::Singapore => lb::MacroeconomicCountry::Singapore,
+        }
+    }
+}
+
+/// Response for macroeconomic_indicators
+#[napi_derive::napi(object)]
+#[derive(Debug, Clone)]
+pub struct MacroeconomicIndicatorListResponse {
+    pub data: Vec<MacroeconomicIndicator>,
+    pub count: i32,
+}
+
+impl From<lb::MacroeconomicIndicatorListResponse> for MacroeconomicIndicatorListResponse {
+    fn from(v: lb::MacroeconomicIndicatorListResponse) -> Self {
+        Self {
+            data: v.data.into_iter().map(Into::into).collect(),
+            count: v.count,
+        }
+    }
+}
+
+/// Metadata for one macroeconomic indicator
+#[napi_derive::napi(object)]
+#[derive(Debug, Clone)]
+pub struct MacroeconomicIndicator {
+    pub indicator_code: String,
+    pub source_org: String,
+    pub country: String,
+    pub name: MultiLanguageText,
+    pub adjustment_factor: String,
+    pub periodicity: String,
+    pub category: String,
+    pub describe: MultiLanguageText,
+    pub importance: i32,
+    /// Start date of data coverage (unix timestamp in seconds; null if unset)
+    pub start_date: Option<i64>,
+}
+
+impl From<lb::MacroeconomicIndicator> for MacroeconomicIndicator {
+    fn from(v: lb::MacroeconomicIndicator) -> Self {
+        Self {
+            indicator_code: v.indicator_code,
+            source_org: v.source_org,
+            country: v.country,
+            name: v.name.into(),
+            adjustment_factor: v.adjustment_factor,
+            periodicity: v.periodicity,
+            category: v.category,
+            describe: v.describe.into(),
+            importance: v.importance,
+            start_date: v.start_date.map(|dt| dt.unix_timestamp()),
+        }
+    }
+}
+
+/// One historical data point for a macroeconomic indicator
+#[napi_derive::napi(object)]
+#[derive(Debug, Clone)]
+pub struct Macroeconomic {
+    pub period: String,
+    /// Release datetime (unix timestamp in seconds; null if unset)
+    pub release_at: Option<i64>,
+    pub actual_value: String,
+    pub previous_value: String,
+    pub forecast_value: String,
+    pub revised_value: String,
+    /// Next release datetime (unix timestamp in seconds; null if unset)
+    pub next_release_at: Option<i64>,
+    pub unit: MultiLanguageText,
+    pub unit_prefix: MultiLanguageText,
+}
+
+impl From<lb::Macroeconomic> for Macroeconomic {
+    fn from(v: lb::Macroeconomic) -> Self {
+        Self {
+            period: v.period,
+            release_at: v.release_at.map(|dt| dt.unix_timestamp()),
+            actual_value: v.actual_value,
+            previous_value: v.previous_value,
+            forecast_value: v.forecast_value,
+            revised_value: v.revised_value,
+            next_release_at: v.next_release_at.map(|dt| dt.unix_timestamp()),
+            unit: v.unit.into(),
+            unit_prefix: v.unit_prefix.into(),
+        }
+    }
+}
+
+/// Response for macroeconomic
+#[napi_derive::napi(object)]
+#[derive(Debug, Clone)]
+pub struct MacroeconomicResponse {
+    pub info: MacroeconomicIndicator,
+    pub data: Vec<Macroeconomic>,
+    pub count: i32,
+}
+
+impl From<lb::MacroeconomicResponse> for MacroeconomicResponse {
+    fn from(v: lb::MacroeconomicResponse) -> Self {
+        Self {
+            info: v.info.into(),
+            data: v.data.into_iter().map(Into::into).collect(),
+            count: v.count,
+        }
+    }
+}

--- a/python/pysrc/longbridge/openapi.pyi
+++ b/python/pysrc/longbridge/openapi.pyi
@@ -9922,6 +9922,44 @@ class FundamentalContext:
         """
         ...
 
+    def macroeconomic_indicators(
+        self,
+        offset: int | None = None,
+        limit: int | None = None,
+    ) -> list["MacroeconomicIndicator"]:
+        """
+        List macroeconomic indicators.
+
+        Args:
+            offset: Pagination offset (default 0)
+            limit: Page size (default 100, max 1000)
+
+        Returns:
+            List of :class:`MacroeconomicIndicator`
+        """
+        ...
+
+    def macroeconomic(
+        self,
+        indicator_code: str,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        limit: int | None = None,
+    ) -> "MacroeconomicResponse":
+        """
+        Get historical data for a macroeconomic indicator.
+
+        Args:
+            indicator_code: External vendor code from ``macroeconomic_indicators``
+            start_date: Start date in ``"YYYY-MM-DD"`` format (optional)
+            end_date: End date in ``"YYYY-MM-DD"`` format (optional)
+            limit: Max records to return (default 100, max 100)
+
+        Returns:
+            :class:`MacroeconomicResponse`
+        """
+        ...
+
 
 # ── FundamentalContext new response types ─────────────────────────
 
@@ -10063,6 +10101,54 @@ class AssetAllocationResponse:
 
     info: list[AssetAllocationGroup]
     """Asset allocation groups"""
+
+
+class MultiLanguageText:
+    """Localized text in simplified Chinese, traditional Chinese, and English."""
+
+    english: str
+    simplified_chinese: str
+    traditional_chinese: str
+
+
+class MacroeconomicIndicator:
+    """Metadata for one macroeconomic indicator."""
+
+    indicator_code: str
+    """External vendor code (input to macroeconomic)"""
+    source_org: str
+    country: str
+    name: MultiLanguageText
+    adjustment_factor: str
+    periodicity: str
+    """Release periodicity (e.g. monthly / quarterly)"""
+    category: str
+    describe: MultiLanguageText
+    importance: int
+    start_date: datetime | None
+    """Start date of data coverage"""
+
+
+class Macroeconomic:
+    """One historical data point for a macroeconomic indicator."""
+
+    period: str
+    """Statistical period (e.g. 2024-Q1, 2024-03)"""
+    release_at: datetime | None
+    actual_value: str
+    previous_value: str
+    forecast_value: str
+    revised_value: str
+    next_release_at: datetime | None
+    unit: MultiLanguageText
+    unit_prefix: MultiLanguageText
+
+
+class MacroeconomicResponse:
+    """Response for macroeconomic."""
+
+    info: MacroeconomicIndicator
+    data: list[Macroeconomic]
 
 
 # ── MarketContext ─────────────────────────────────────────────────

--- a/python/src/fundamental/context.rs
+++ b/python/src/fundamental/context.rs
@@ -208,4 +208,34 @@ impl FundamentalContext {
             .map_err(ErrorNewType)?
             .into())
     }
+
+    /// List macroeconomic indicators.
+    fn macroeconomic_indicators(
+        &self,
+        country: Option<MacroeconomicCountry>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> PyResult<MacroeconomicIndicatorListResponse> {
+        Ok(self
+            .ctx
+            .macroeconomic_indicators(country.map(Into::into), offset, limit)
+            .map_err(ErrorNewType)?
+            .into())
+    }
+
+    /// Get historical data for a macroeconomic indicator.
+    fn macroeconomic(
+        &self,
+        indicator_code: String,
+        start_date: Option<String>,
+        end_date: Option<String>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> PyResult<MacroeconomicResponse> {
+        Ok(self
+            .ctx
+            .macroeconomic(indicator_code, start_date, end_date, offset, limit)
+            .map_err(ErrorNewType)?
+            .into())
+    }
 }

--- a/python/src/fundamental/context_async.rs
+++ b/python/src/fundamental/context_async.rs
@@ -317,4 +317,44 @@ impl AsyncFundamentalContext {
         })
         .map(|b| b.unbind())
     }
+
+    /// List macroeconomic indicators. Returns awaitable.
+    fn macroeconomic_indicators(
+        &self,
+        py: Python<'_>,
+        country: Option<MacroeconomicCountry>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> PyResult<Py<PyAny>> {
+        let ctx = self.ctx.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            Ok(MacroeconomicIndicatorListResponse::from(
+                ctx.macroeconomic_indicators(country.map(Into::into), offset, limit)
+                    .await
+                    .map_err(ErrorNewType)?,
+            ))
+        })
+        .map(|b| b.unbind())
+    }
+
+    /// Get historical data for a macroeconomic indicator. Returns awaitable.
+    fn macroeconomic(
+        &self,
+        py: Python<'_>,
+        indicator_code: String,
+        start_date: Option<String>,
+        end_date: Option<String>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> PyResult<Py<PyAny>> {
+        let ctx = self.ctx.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            Ok(MacroeconomicResponse::from(
+                ctx.macroeconomic(indicator_code, start_date, end_date, offset, limit)
+                    .await
+                    .map_err(ErrorNewType)?,
+            ))
+        })
+        .map(|b| b.unbind())
+    }
 }

--- a/python/src/fundamental/mod.rs
+++ b/python/src/fundamental/mod.rs
@@ -74,6 +74,12 @@ pub(crate) fn register_types(parent: &Bound<PyModule>) -> PyResult<()> {
     parent.add_class::<AssetAllocationItem>()?;
     parent.add_class::<AssetAllocationGroup>()?;
     parent.add_class::<AssetAllocationResponse>()?;
+    parent.add_class::<MultiLanguageText>()?;
+    parent.add_class::<MacroeconomicCountry>()?;
+    parent.add_class::<MacroeconomicIndicatorListResponse>()?;
+    parent.add_class::<MacroeconomicIndicator>()?;
+    parent.add_class::<Macroeconomic>()?;
+    parent.add_class::<MacroeconomicResponse>()?;
     parent.add_class::<context::FundamentalContext>()?;
     parent.add_class::<context_async::AsyncFundamentalContext>()?;
     Ok(())

--- a/python/src/fundamental/types.rs
+++ b/python/src/fundamental/types.rs
@@ -1965,3 +1965,149 @@ impl From<lb::AssetAllocationResponse> for AssetAllocationResponse {
         }
     }
 }
+
+// ── economic_indicator ─────────────────────────────────────────────────────
+
+/// Localized text in simplified Chinese, traditional Chinese, and English
+#[pyclass(get_all, skip_from_py_object)]
+#[derive(Debug, Clone, Default)]
+pub(crate) struct MultiLanguageText {
+    pub english: String,
+    pub simplified_chinese: String,
+    pub traditional_chinese: String,
+}
+
+impl From<lb::MultiLanguageText> for MultiLanguageText {
+    fn from(v: lb::MultiLanguageText) -> Self {
+        Self {
+            english: v.english,
+            simplified_chinese: v.simplified_chinese,
+            traditional_chinese: v.traditional_chinese,
+        }
+    }
+}
+
+/// Country code for filtering macroeconomic indicators
+#[pyclass]
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum MacroeconomicCountry {
+    HongKong,
+    China,
+    UnitedStates,
+    EuroZone,
+    Japan,
+    Singapore,
+}
+
+impl From<MacroeconomicCountry> for lb::MacroeconomicCountry {
+    fn from(v: MacroeconomicCountry) -> Self {
+        match v {
+            MacroeconomicCountry::HongKong => lb::MacroeconomicCountry::HongKong,
+            MacroeconomicCountry::China => lb::MacroeconomicCountry::China,
+            MacroeconomicCountry::UnitedStates => lb::MacroeconomicCountry::UnitedStates,
+            MacroeconomicCountry::EuroZone => lb::MacroeconomicCountry::EuroZone,
+            MacroeconomicCountry::Japan => lb::MacroeconomicCountry::Japan,
+            MacroeconomicCountry::Singapore => lb::MacroeconomicCountry::Singapore,
+        }
+    }
+}
+
+/// Response for macroeconomic_indicators
+#[pyclass(get_all, skip_from_py_object)]
+#[derive(Debug, Clone)]
+pub(crate) struct MacroeconomicIndicatorListResponse {
+    pub data: Vec<MacroeconomicIndicator>,
+    pub count: i32,
+}
+
+impl From<lb::MacroeconomicIndicatorListResponse> for MacroeconomicIndicatorListResponse {
+    fn from(v: lb::MacroeconomicIndicatorListResponse) -> Self {
+        Self {
+            data: v.data.into_iter().map(Into::into).collect(),
+            count: v.count,
+        }
+    }
+}
+
+/// Metadata for one macroeconomic indicator
+#[pyclass(get_all, skip_from_py_object)]
+#[derive(Debug, Clone)]
+pub(crate) struct MacroeconomicIndicator {
+    pub indicator_code: String,
+    pub source_org: String,
+    pub country: String,
+    pub name: MultiLanguageText,
+    pub adjustment_factor: String,
+    pub periodicity: String,
+    pub category: String,
+    pub describe: MultiLanguageText,
+    pub importance: i32,
+    pub start_date: Option<crate::time::PyOffsetDateTimeWrapper>,
+}
+
+impl From<lb::MacroeconomicIndicator> for MacroeconomicIndicator {
+    fn from(v: lb::MacroeconomicIndicator) -> Self {
+        Self {
+            indicator_code: v.indicator_code,
+            source_org: v.source_org,
+            country: v.country,
+            name: v.name.into(),
+            adjustment_factor: v.adjustment_factor,
+            periodicity: v.periodicity,
+            category: v.category,
+            describe: v.describe.into(),
+            importance: v.importance,
+            start_date: v.start_date.map(crate::time::PyOffsetDateTimeWrapper),
+        }
+    }
+}
+
+/// One historical data point for a macroeconomic indicator
+#[pyclass(get_all, skip_from_py_object)]
+#[derive(Debug, Clone)]
+pub(crate) struct Macroeconomic {
+    pub period: String,
+    pub release_at: Option<crate::time::PyOffsetDateTimeWrapper>,
+    pub actual_value: String,
+    pub previous_value: String,
+    pub forecast_value: String,
+    pub revised_value: String,
+    pub next_release_at: Option<crate::time::PyOffsetDateTimeWrapper>,
+    pub unit: MultiLanguageText,
+    pub unit_prefix: MultiLanguageText,
+}
+
+impl From<lb::Macroeconomic> for Macroeconomic {
+    fn from(v: lb::Macroeconomic) -> Self {
+        Self {
+            period: v.period,
+            release_at: v.release_at.map(crate::time::PyOffsetDateTimeWrapper),
+            actual_value: v.actual_value,
+            previous_value: v.previous_value,
+            forecast_value: v.forecast_value,
+            revised_value: v.revised_value,
+            next_release_at: v.next_release_at.map(crate::time::PyOffsetDateTimeWrapper),
+            unit: v.unit.into(),
+            unit_prefix: v.unit_prefix.into(),
+        }
+    }
+}
+
+/// Response for macroeconomic
+#[pyclass(get_all, skip_from_py_object)]
+#[derive(Debug, Clone)]
+pub(crate) struct MacroeconomicResponse {
+    pub info: MacroeconomicIndicator,
+    pub data: Vec<Macroeconomic>,
+    pub count: i32,
+}
+
+impl From<lb::MacroeconomicResponse> for MacroeconomicResponse {
+    fn from(v: lb::MacroeconomicResponse) -> Self {
+        Self {
+            info: v.info.into(),
+            data: v.data.into_iter().map(Into::into).collect(),
+            count: v.count,
+        }
+    }
+}

--- a/rust/src/blocking/fundamental.rs
+++ b/rust/src/blocking/fundamental.rs
@@ -290,4 +290,31 @@ impl FundamentalContextSync {
         self.rt
             .call(move |ctx| async move { ctx.etf_asset_allocation(symbol).await })
     }
+
+    /// List macroeconomic indicators
+    pub fn macroeconomic_indicators(
+        &self,
+        country: Option<MacroeconomicCountry>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> Result<MacroeconomicIndicatorListResponse> {
+        self.rt.call(move |ctx| async move {
+            ctx.macroeconomic_indicators(country, offset, limit).await
+        })
+    }
+
+    /// Get historical data for a macroeconomic indicator
+    pub fn macroeconomic(
+        &self,
+        indicator_code: impl Into<String> + Send + 'static,
+        start_date: Option<impl Into<String> + Send + 'static>,
+        end_date: Option<impl Into<String> + Send + 'static>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> Result<MacroeconomicResponse> {
+        self.rt.call(move |ctx| async move {
+            ctx.macroeconomic(indicator_code, start_date, end_date, offset, limit)
+                .await
+        })
+    }
 }

--- a/rust/src/fundamental/context.rs
+++ b/rust/src/fundamental/context.rs
@@ -829,4 +829,93 @@ impl FundamentalContext {
         )
         .await
     }
+
+    // ── macroeconomic ────────────────────────────────────────────────
+
+    /// List macroeconomic indicators.
+    ///
+    /// Pass `country` to filter by country code (e.g.
+    /// `MacroeconomicCountry::UnitedStates`).
+    ///
+    /// Path: `GET /v1/quote/macrodata`
+    pub async fn macroeconomic_indicators(
+        &self,
+        country: Option<MacroeconomicCountry>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> Result<MacroeconomicIndicatorListResponse> {
+        #[derive(Serialize)]
+        struct Query {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            country: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            offset: Option<i32>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            limit: Option<i32>,
+        }
+        let country_str = country.map(|c| {
+            match c {
+                MacroeconomicCountry::HongKong => "Hong Kong SAR China",
+                MacroeconomicCountry::China => "China (Mainland)",
+                MacroeconomicCountry::UnitedStates => "United States",
+                MacroeconomicCountry::EuroZone => "Euro Zone",
+                MacroeconomicCountry::Japan => "Japan",
+                MacroeconomicCountry::Singapore => "Singapore",
+            }
+            .to_string()
+        });
+        self.get(
+            "/v1/quote/macrodata",
+            Query {
+                country: country_str,
+                offset,
+                limit,
+            },
+        )
+        .await
+    }
+
+    /// Get historical data for a macroeconomic indicator.
+    ///
+    /// `start_date` and `end_date` are date strings in `"YYYY-MM-DD"` format.
+    /// `start_date` is sent as `YYYY-MM-DDT00:00:00Z`; `end_date` is sent as
+    /// `YYYY-MM-DDT23:59:59Z`.
+    ///
+    /// Path: `GET /v1/quote/macrodata/{indicator_code}`
+    pub async fn macroeconomic(
+        &self,
+        indicator_code: impl Into<String>,
+        start_date: Option<impl Into<String>>,
+        end_date: Option<impl Into<String>>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> Result<MacroeconomicResponse> {
+        #[derive(Serialize)]
+        struct Query {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            start_time: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            end_time: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            offset: Option<i32>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            limit: Option<i32>,
+        }
+        let path = format!("/v1/quote/macrodata/{}", indicator_code.into());
+        Ok(self
+            .0
+            .http_cli
+            .request(Method::GET, path)
+            .query_params(Query {
+                start_time: start_date.map(|d| format!("{}T00:00:00Z", d.into())),
+                end_time: end_date.map(|d| format!("{}T23:59:59Z", d.into())),
+                offset,
+                limit,
+            })
+            .response::<Json<MacroeconomicResponse>>()
+            .send()
+            .with_subscriber(self.0.log_subscriber.clone())
+            .await?
+            .0)
+    }
 }

--- a/rust/src/fundamental/types.rs
+++ b/rust/src/fundamental/types.rs
@@ -1562,3 +1562,160 @@ pub struct AssetAllocationResponse {
     #[serde(default)]
     pub info: Vec<AssetAllocationGroup>,
 }
+
+// ── macroeconomic ─────────────────────────────────────────────────────
+
+/// Country for filtering macroeconomic indicators
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum MacroeconomicCountry {
+    /// Hong Kong SAR China
+    #[serde(rename = "Hong Kong SAR China")]
+    HongKong,
+    /// China (Mainland)
+    #[serde(rename = "China (Mainland)")]
+    China,
+    /// United States
+    #[serde(rename = "United States")]
+    UnitedStates,
+    /// Euro Zone
+    #[serde(rename = "Euro Zone")]
+    EuroZone,
+    /// Japan
+    #[serde(rename = "Japan")]
+    Japan,
+    /// Singapore
+    #[serde(rename = "Singapore")]
+    Singapore,
+}
+
+/// Importance level of a macroeconomic indicator
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum MacroeconomicImportance {
+    /// Low importance
+    Low = 1,
+    /// Medium importance
+    Medium = 2,
+    /// High importance
+    High = 3,
+}
+
+impl MacroeconomicImportance {
+    /// Convert from raw API integer value
+    pub fn from_i32(v: i32) -> Option<Self> {
+        match v {
+            1 => Some(Self::Low),
+            2 => Some(Self::Medium),
+            3 => Some(Self::High),
+            _ => None,
+        }
+    }
+}
+
+/// Localized text in simplified Chinese, traditional Chinese, and English
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MultiLanguageText {
+    /// English
+    #[serde(default)]
+    pub english: String,
+    /// Simplified Chinese
+    #[serde(default)]
+    pub simplified_chinese: String,
+    /// Traditional Chinese
+    #[serde(default)]
+    pub traditional_chinese: String,
+}
+
+/// Metadata for one macroeconomic indicator
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MacroeconomicIndicator {
+    /// External vendor code (used as input to `macroeconomic`)
+    pub indicator_code: String,
+    /// Publishing organisation
+    #[serde(default)]
+    pub source_org: String,
+    /// Country
+    #[serde(default)]
+    pub country: String,
+    /// Indicator name (multilingual)
+    #[serde(default, deserialize_with = "crate::serde_utils::null_as_default")]
+    pub name: MultiLanguageText,
+    /// Adjustment factor
+    #[serde(default)]
+    pub adjustment_factor: String,
+    /// Release periodicity (e.g. `monthly` / `quarterly`)
+    #[serde(default)]
+    pub periodicity: String,
+    /// Indicator category
+    #[serde(default)]
+    pub category: String,
+    /// Description (multilingual)
+    #[serde(default, deserialize_with = "crate::serde_utils::null_as_default")]
+    pub describe: MultiLanguageText,
+    /// Importance — higher is more important
+    #[serde(default)]
+    pub importance: i32,
+    /// Start date of data coverage
+    #[serde(
+        default,
+        with = "crate::serde_utils::rfc3339_opt",
+        rename = "start_date"
+    )]
+    pub start_date: Option<OffsetDateTime>,
+}
+
+/// Response for [`crate::FundamentalContext::macroeconomic_indicators`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MacroeconomicIndicatorListResponse {
+    /// Indicator list
+    #[serde(default, rename = "list")]
+    pub data: Vec<MacroeconomicIndicator>,
+    /// Total number of indicators matching the query
+    #[serde(default)]
+    pub count: i32,
+}
+
+/// One historical data point for a macroeconomic indicator
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Macroeconomic {
+    /// Statistical period (e.g. `2024-Q1`, `2024-03`)
+    #[serde(default)]
+    pub period: String,
+    /// Release datetime
+    #[serde(default, with = "crate::serde_utils::rfc3339_opt")]
+    pub release_at: Option<OffsetDateTime>,
+    /// Actual value
+    #[serde(default)]
+    pub actual_value: String,
+    /// Previous value
+    #[serde(default)]
+    pub previous_value: String,
+    /// Forecast value (market consensus)
+    #[serde(default)]
+    pub forecast_value: String,
+    /// Revised value
+    #[serde(default)]
+    pub revised_value: String,
+    /// Next release datetime
+    #[serde(default, with = "crate::serde_utils::rfc3339_opt")]
+    pub next_release_at: Option<OffsetDateTime>,
+    /// Unit (multilingual)
+    #[serde(default, deserialize_with = "crate::serde_utils::null_as_default")]
+    pub unit: MultiLanguageText,
+    /// Unit prefix / data scale (multilingual, e.g. millions / billions)
+    #[serde(default, deserialize_with = "crate::serde_utils::null_as_default")]
+    pub unit_prefix: MultiLanguageText,
+}
+
+/// Response for [`crate::FundamentalContext::macroeconomic`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MacroeconomicResponse {
+    /// Indicator metadata
+    #[serde(default, deserialize_with = "crate::serde_utils::null_as_default")]
+    pub info: MacroeconomicIndicator,
+    /// Historical data points
+    #[serde(default)]
+    pub data: Vec<Macroeconomic>,
+    /// Total number of historical data points
+    #[serde(default)]
+    pub count: i32,
+}

--- a/rust/src/serde_utils.rs
+++ b/rust/src/serde_utils.rs
@@ -462,3 +462,12 @@ where
         StringOrInt::String(s) => s.parse::<i64>().map_err(serde::de::Error::custom),
     }
 }
+
+/// Deserializer that maps a JSON `null` to the type's `Default` value.
+pub(crate) fn null_as_default<'de, D, T>(d: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + Default,
+{
+    Ok(Option::<T>::deserialize(d)?.unwrap_or_default())
+}


### PR DESCRIPTION
Merge main into release to publish 4.3.1.

## Changes in 4.3.1

### Added

- **All languages:** `macroeconomic_indicators(country, offset, limit)` — list macroeconomic indicators via `GET /v1/quote/macrodata`; filter by `MacroeconomicCountry` (HK/CN/US/EU/JP/SG); response includes `count`
- **All languages:** `macroeconomic(indicator_code, start_date, end_date, offset, limit)` — historical data for a specific indicator; response includes `count`
- New types: `MultiLanguageText`, `MacroeconomicCountry`, `MacroeconomicImportance`, `MacroeconomicIndicator`, `MacroeconomicIndicatorListResponse`, `Macroeconomic`, `MacroeconomicResponse`

### Fixed

- `MacroeconomicIndicator.describe` / `name` / `MacroeconomicResponse.info`: handle `null` API responses