### PR TITLE
chore: release 4.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.2] - 2026-06-13
+
+### Added
+
+- **All languages:** `FundamentalContext.macroeconomic_indicators(country, keyword, offset, limit)` — `keyword` parameter for fuzzy-filtering indicators by name (case-insensitive)
+- **All languages:** `FundamentalContext.macroeconomic(indicator_code, start_date, end_date, offset, limit)` — GET `/v2/quote/macrodata/{indicator_id}`; defaults to `sort=desc`
+- `MacroeconomicIndicator` now includes `name` (string), `describe` (string), `periodicity`, `importance` from v2 API
+- `Macroeconomic` data points include `unit` (string) from v2 API
+
+### Changed
+
+- `MacroeconomicIndicator.name` and `.describe` changed from `MultiLanguageText` to `string`
+- `Macroeconomic.unit` and `.unit_prefix` changed from `MultiLanguageText` to `string`
+
 ## [4.3.1] - 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **All languages:** `FundamentalContext.macroeconomic_indicators(country, keyword, offset, limit)` — `keyword` parameter for fuzzy-filtering indicators by name (case-insensitive)
-- **All languages:** `FundamentalContext.macroeconomic(indicator_code, start_date, end_date, offset, limit)` — GET `/v2/quote/macrodata/{indicator_id}`; defaults to `sort=desc`
-- `MacroeconomicIndicator` now includes `name` (string), `describe` (string), `periodicity`, `importance` from v2 API
-- `Macroeconomic` data points include `unit` (string) from v2 API
+- **All languages:** `macroeconomic_indicators` gains `keyword` parameter for fuzzy name filtering
+- **All languages:** `macroeconomic` switches to `GET /v2/quote/macrodata/{id}`, defaults to `sort=desc`
 
 ### Changed
 
-- `MacroeconomicIndicator.name` and `.describe` changed from `MultiLanguageText` to `string`
-- `Macroeconomic.unit` and `.unit_prefix` changed from `MultiLanguageText` to `string`
+- `MacroeconomicIndicator.name` / `.describe`: `MultiLanguageText` → `string`
+- `Macroeconomic.unit` / `.unit_prefix`: `MultiLanguageText` → `string`
 
 ## [4.3.1] - 2026-06-12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["rust", "python", "nodejs", "java", "c"]
 
 [workspace.package]
-version = "4.3.1"
+version = "4.3.2"
 edition = "2024"
 
 [profile.release]


### PR DESCRIPTION
## Changes in 4.3.2

### Added

- **All languages:** `macroeconomic_indicators(country, keyword, offset, limit)` — `keyword` for fuzzy-filtering indicators by name
- **All languages:** `macroeconomic(indicator_code, ...)` — uses GET `/v2/quote/macrodata/{id}`; defaults to `sort=desc`
- `MacroeconomicIndicator` now includes `name`, `describe`, `periodicity`, `importance` from v2 API
- `Macroeconomic` includes `unit` from v2 API

### Changed

- `MacroeconomicIndicator.name` / `.describe`: `MultiLanguageText` → `string`
- `Macroeconomic.unit` / `.unit_prefix`: `MultiLanguageText` → `string`

## Related

- PR #540 (macroeconomic v2 feature branch)