### PR TITLE
fix: align market trade status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Rust:** `market::TradeStatus` models `/v1/quote/market-status` trade status codes, including engine-compatible normalization and display helpers.
+
+### Fixed
+
+- **All languages:** corrected market trade status documentation and aligned `market::TradeStatus` with the status definition table, including code `2001` and the `123`/`1009`/`1010` display names.
+
 ## [4.3.2] - 2026-06-13
 
 ### Added

--- a/c/csrc/include/longbridge.h
+++ b/c/csrc/include/longbridge.h
@@ -4575,7 +4575,8 @@ typedef struct lb_market_time_item_t {
    */
   enum lb_market_t market;
   /**
-   * Current trade status code for the market.
+   * Current market trade status code. See the market status definition for
+   * the complete code table.
    */
   int32_t trade_status;
   /**
@@ -4583,7 +4584,7 @@ typedef struct lb_market_time_item_t {
    */
   const char *timestamp;
   /**
-   * Delayed trade status code for the market.
+   * Delayed market trade status code.
    */
   int32_t delay_trade_status;
   /**

--- a/c/src/market_context/types.rs
+++ b/c/src/market_context/types.rs
@@ -18,11 +18,12 @@ use crate::types::{CMarket, CString, CVec, ToFFI};
 pub struct CMarketTimeItem {
     /// Market identifier.
     pub market: CMarket,
-    /// Current trade status code for the market.
+    /// Current market trade status code. See the market status definition for
+    /// the complete code table.
     pub trade_status: i32,
     /// Timestamp of the current trade status as an ISO-8601 string.
     pub timestamp: *const c_char,
-    /// Delayed trade status code for the market.
+    /// Delayed market trade status code.
     pub delay_trade_status: i32,
     /// Timestamp of the delayed trade status as an ISO-8601 string.
     pub delay_timestamp: *const c_char,

--- a/java/javasrc/src/main/java/com/longbridge/market/MarketTimeItem.java
+++ b/java/javasrc/src/main/java/com/longbridge/market/MarketTimeItem.java
@@ -5,14 +5,13 @@ public class MarketTimeItem {
     /** Market. */
     public com.longbridge.Market market;
     /**
-     * Raw trade status code.
-     * 101=PreOpen, 102/103/105=Trading, 104=LunchBreak, 106=PostTrading,
-     * 108=Closed, 201=PreMarket, 204=PostMarket.
+     * Raw market trade status code.
+     * See the market status definition for the complete code table.
      */
     public int tradeStatus;
     /** Current market time (unix timestamp string). */
     public String timestamp;
-    /** Delayed-quote trade status code. */
+    /** Delayed-quote market trade status code. */
     public int delayTradeStatus;
     /** Delayed-quote market time (unix timestamp string). */
     public String delayTimestamp;

--- a/nodejs/index.d.ts
+++ b/nodejs/index.d.ts
@@ -619,13 +619,9 @@ export declare class FundamentalContext {
    */
   etfAssetAllocation(symbol: string): Promise<AssetAllocationResponse>
   /** List macroeconomic indicators */
-  macroeconomicIndicators(country?: MacroeconomicCountry | undefined | null, offset?: number | undefined | null, limit?: number | undefined | null): Promise<MacroeconomicIndicatorListResponse>
+  macroeconomicIndicators(country?: MacroeconomicCountry | undefined | null, keyword?: string | undefined | null, offset?: number | undefined | null, limit?: number | undefined | null): Promise<MacroeconomicIndicatorListResponse>
   /** Get historical data for a macroeconomic indicator */
   macroeconomic(indicatorCode: string, startDate?: string | undefined | null, endDate?: string | undefined | null, offset?: number | undefined | null, limit?: number | undefined | null): Promise<MacroeconomicResponse>
-  /** List macroeconomic indicators (v2) with optional keyword filter */
-  macroeconomicIndicatorsV2(country?: MacroeconomicCountry | undefined | null, keyword?: string | undefined | null, offset?: number | undefined | null, limit?: number | undefined | null): Promise<MacroeconomicIndicatorListResponse>
-  /** Get historical data for a macroeconomic indicator (v2) with sort support */
-  macroeconomicV2(indicatorCode: string, startDate?: string | undefined | null, endDate?: string | undefined | null, offset?: number | undefined | null, limit?: number | undefined | null, sort?: string | undefined | null): Promise<MacroeconomicResponse>
 }
 
 /** Fund position */
@@ -4566,13 +4562,13 @@ export interface MarketTimeItem {
   /** Market */
   market: Market
   /**
-   * Raw trade status code (101=PreOpen, 102/103/105=Trading, 104=LunchBreak,
-   * 106=PostTrading, 108=Closed, 201=PreMarket, 204=PostMarket)
+   * Raw market trade status code. See the market status definition for the
+   * complete code table.
    */
   tradeStatus: number
   /** Current market time (unix timestamp string) */
   timestamp: string
-  /** Delayed-quote trade status code */
+  /** Delayed-quote market trade status code */
   delayTradeStatus: number
   /** Delayed-quote market time (unix timestamp string) */
   delayTimestamp: string

--- a/nodejs/src/market/types.rs
+++ b/nodejs/src/market/types.rs
@@ -22,12 +22,12 @@ impl From<lb::MarketStatusResponse> for MarketStatusResponse {
 pub struct MarketTimeItem {
     /// Market
     pub market: crate::types::Market,
-    /// Raw trade status code (101=PreOpen, 102/103/105=Trading, 104=LunchBreak,
-    /// 106=PostTrading, 108=Closed, 201=PreMarket, 204=PostMarket)
+    /// Raw market trade status code. See the market status definition for the
+    /// complete code table.
     pub trade_status: i32,
     /// Current market time (unix timestamp string)
     pub timestamp: String,
-    /// Delayed-quote trade status code
+    /// Delayed-quote market trade status code
     pub delay_trade_status: i32,
     /// Delayed-quote market time (unix timestamp string)
     pub delay_timestamp: String,

--- a/python/pysrc/longbridge/openapi.pyi
+++ b/python/pysrc/longbridge/openapi.pyi
@@ -10159,11 +10159,11 @@ class MarketTimeItem:
     market: Market
     """Market"""
     trade_status: int
-    """Raw trade status code (101=PreOpen, 102/105=Trading, 104=LunchBreak, 106=PostTrading, 108=Closed, 201=PreMarket, 204=PostMarket)"""
+    """Raw market trade status code. See the market status definition for the complete code table."""
     timestamp: str
     """Current market time (unix timestamp string)"""
     delay_trade_status: int
-    """Delayed-quote trade status code"""
+    """Delayed-quote market trade status code"""
     delay_timestamp: str
     """Delayed-quote market time (unix timestamp string)"""
     sub_status: int

--- a/python/src/market/types.rs
+++ b/python/src/market/types.rs
@@ -217,11 +217,12 @@ impl From<lb::MarketStatusResponse> for MarketStatusResponse {
 pub(crate) struct MarketTimeItem {
     /// Market
     pub market: crate::types::Market,
-    /// Raw trade status code
+    /// Raw market trade status code. See the market status definition for the
+    /// complete code table.
     pub trade_status: i32,
     /// Current market time (unix timestamp string)
     pub timestamp: String,
-    /// Delayed-quote trade status code
+    /// Delayed-quote market trade status code
     pub delay_trade_status: i32,
     /// Delayed-quote time (unix timestamp string)
     pub delay_timestamp: String,

--- a/rust/src/market/types.rs
+++ b/rust/src/market/types.rs
@@ -35,76 +35,81 @@ pub enum TradeStatus {
     UNKNOWN = -1,
     /// Quote is not registered
     NO_REGISTER_QUOTE = 0,
-    /// Clearing
+    /// Clearing before the market opens.
     CLEAN = 101,
-    /// Opening auction
+    /// Opening auction.
     OPEN_BID = 102,
-    /// Morning break, currently used by VIX indexes
+    /// Morning break, currently used by VIX indexes.
     MORNING_CLOSING = 103,
-    /// Trading
+    /// Regular trading.
     TRADING = 105,
-    /// Midday break
+    /// Midday break.
     NOON_CLOSING = 106,
-    /// Closing auction
+    /// Closing auction.
     CLOSE_BID = 107,
-    /// Closed
+    /// Market closed.
     CLOSING = 108,
-    /// Dark pool waiting to open
+    /// Dark trading waiting to open.
     DARK_WAIT = 110,
-    /// Dark pool trading
+    /// Dark trading.
     DARK_TRADING = 111,
-    /// Dark pool closed
+    /// Dark trading closed.
     DARK_CLOSING = 112,
-    /// After-hours fixed-price trading
+    /// After-hours fixed-price trading.
     AFTER_FIX = 120,
-    /// Half-day market closed
+    /// Half-day market closed. Defined by the market status table but currently
+    /// unused.
     HALF_CLOSING = 121,
-    /// Not opened
+    /// Not opened because the exchange is waiting to open under special
+    /// conditions.
     NOT_OPENED = 122,
-    /// Realtime quotes
+    /// Temporary intraday break. The historical variant name is kept for
+    /// compatibility.
     REALTIME_QUOTE = 123,
-    /// US pre-market
+    /// US pre-market.
     US_PREV = 201,
-    /// US regular trading
+    /// US regular trading.
     US_TRADING = 202,
-    /// US post-market
+    /// US post-market.
     US_AFTER = 203,
-    /// US closed
+    /// US closed.
     US_CLOSING = 204,
-    /// US halted
+    /// US halted.
     US_STOP = 205,
-    /// US clearing before pre-market
+    /// US clearing plus pre-market.
     US_CLEAN = 206,
-    /// US overnight trading
+    /// US overnight trading.
     US_NIGHT = 207,
-    /// US pre-market clearing
+    /// US pre-market clearing alias returned by the quote engine.
     US_PREV_MARKET_CLEAN = 209,
-    /// US post-market clearing
+    /// US post-market clearing alias returned by the quote engine.
     US_AFTER_MARKET_CLEAN = 210,
-    /// Stock refresh
+    /// Stock refresh. Deprecated in the status definition.
     REFRESH = 1000,
-    /// Delisted
+    /// Delisted.
     DELIST = 1001,
-    /// Preparing to list
+    /// Preparing to list.
     PREPARE = 1002,
-    /// Code changed
+    /// Code changed.
     CODE_CHANGE = 1003,
-    /// Halted
+    /// Halted.
     STOP = 1004,
-    /// Waiting to open
+    /// Waiting to open, typically for a US IPO auction.
     WILL_OPEN = 1005,
-    /// Split or merge suspended
+    /// Split or merge suspended.
     COMMON_SUSPEND = 1006,
-    /// Expired
+    /// Expired.
     EXPIRE = 1007,
-    /// No quote
+    /// No quote data.
     NO_QUOTE = 1008,
-    /// Not listed
+    /// Not listed. The historical variant name is kept for compatibility.
     UNITED = 1009,
-    /// Trading halted
+    /// Terminated trading, usually for warrants.
     TRADING_HALT = 1010,
-    /// Waiting to list
+    /// Waiting to list, usually for new warrants.
     WAIT_LISTING = 1011,
+    /// Fuse.
+    FUSE = 2001,
 }
 
 impl From<i32> for TradeStatus {
@@ -165,7 +170,7 @@ impl TradeStatus {
             TradeStatus::DARK_CLOSING => "Closing",
             TradeStatus::AFTER_FIX => "After Fix",
             TradeStatus::NOT_OPENED => "Not Open",
-            TradeStatus::REALTIME_QUOTE => "Realtime Quotes",
+            TradeStatus::REALTIME_QUOTE => "Temporary Break",
             TradeStatus::US_PREV | TradeStatus::US_CLEAN => "Pre-Market",
             TradeStatus::US_AFTER => "Post-Market",
             TradeStatus::US_STOP | TradeStatus::STOP => "Stop",
@@ -178,9 +183,10 @@ impl TradeStatus {
             TradeStatus::COMMON_SUSPEND => "Common Suspend",
             TradeStatus::EXPIRE => "Expire",
             TradeStatus::NO_QUOTE => "No Quote",
-            TradeStatus::UNITED => "United",
-            TradeStatus::TRADING_HALT => "Trading Halt",
+            TradeStatus::UNITED => "Not Listed",
+            TradeStatus::TRADING_HALT => "Terminated",
             TradeStatus::WAIT_LISTING => "Wait Listing",
+            TradeStatus::FUSE => "Fuse",
         }
     }
 
@@ -288,11 +294,12 @@ pub struct MarketStatusResponse {
 pub struct MarketTimeItem {
     /// Market code
     pub market: Market,
-    /// Trade status
+    /// Market trade status. See [`TradeStatus`] for the code table.
     pub trade_status: TradeStatus,
     /// Current market time (unix timestamp string)
     pub timestamp: String,
-    /// Delayed-quote trade status
+    /// Delayed-quote market trade status. See [`TradeStatus`] for the code
+    /// table.
     pub delay_trade_status: TradeStatus,
     /// Delayed-quote market time (unix timestamp string)
     pub delay_timestamp: String,
@@ -360,16 +367,48 @@ mod tests {
         let cases = [
             (TradeStatus::MORNING_CLOSING, "Morning Break"),
             (TradeStatus::NOON_CLOSING, "Mid-Day Break"),
-            (TradeStatus::REALTIME_QUOTE, "Realtime Quotes"),
+            (TradeStatus::REALTIME_QUOTE, "Temporary Break"),
             (TradeStatus::US_STOP, "Stop"),
-            (TradeStatus::TRADING_HALT, "Trading Halt"),
+            (TradeStatus::TRADING_HALT, "Terminated"),
             (TradeStatus::WAIT_LISTING, "Wait Listing"),
+            (TradeStatus::FUSE, "Fuse"),
             (TradeStatus::UNKNOWN, "Unknown"),
             (TradeStatus::NO_REGISTER_QUOTE, "Unknown"),
         ];
 
         for (status, expected) in cases {
             assert_eq!(status.name(), expected, "status {status:?}");
+        }
+    }
+
+    #[test]
+    fn market_trade_status_codes_match_phase_definition_document() {
+        let codes = [
+            101, 102, 103, 105, 106, 107, 108, 110, 111, 112, 120, 121, 122, 123, 201, 202, 203,
+            204, 206, 207, 1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010, 1011,
+            2001,
+        ];
+
+        for code in codes {
+            assert_eq!(TradeStatus::from(code).code(), code, "status code {code}");
+        }
+    }
+
+    #[test]
+    fn market_trade_status_names_match_phase_definition_document() {
+        let cases = [
+            (123, "Temporary Break"),
+            (1009, "Not Listed"),
+            (1010, "Terminated"),
+            (2001, "Fuse"),
+        ];
+
+        for (code, expected) in cases {
+            assert_eq!(
+                TradeStatus::from(code).name(),
+                expected,
+                "status code {code}"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- Align Rust market TradeStatus codes with the phase/status definition, including code 2001.
- Correct display names for status codes 123, 1009, and 1010 while keeping existing Rust variant names compatible.
- Refresh SDK comments/generated bindings for market trade status fields.

## Test Plan
- cargo +nightly fmt --all -- --check
- cargo test -p longbridge market_trade_status_ --lib
- RUSTC_WRAPPER= cargo clippy --all --all-features
- PATH=/opt/homebrew/bin:/usr/local/bin:$PATH RUSTC_WRAPPER= npm run build:debug
- RUSTC_WRAPPER= cargo build -p longbridge-c