### PR TITLE
fix(macroeconomic): add frequence and importance to detail info

### DIFF
--- a/rust/src/fundamental/context.rs
+++ b/rust/src/fundamental/context.rs
@@ -993,6 +993,8 @@ impl FundamentalContext {
             country: detail.market,
             name: detail.indicator_name,
             describe: detail.description,
+            periodicity: detail.frequence,
+            importance: detail.importance,
             ..Default::default()
         };
 

--- a/rust/src/fundamental/types.rs
+++ b/rust/src/fundamental/types.rs
@@ -1779,6 +1779,10 @@ pub(crate) struct V2MacroIndicatorDetail {
     #[serde(default)]
     pub market: String,
     #[serde(default)]
+    pub frequence: String,
+    #[serde(default)]
+    pub importance: i32,
+    #[serde(default)]
     pub indicator_data: Vec<V2IndicatorDataDetail>,
 }
 


### PR DESCRIPTION
## Summary

- `V2MacroIndicatorDetail` wire type gains `frequence` and `importance` fields
- `MacroeconomicResponse.info.periodicity` and `.importance` are now populated in the detail endpoint response

Previously these fields were always default (empty string / 0) in the detail response (`GET /v2/quote/macrodata/{id}`), even though the list endpoint returned them correctly. Python / Node.js / Java benefit automatically via `From<lb::MacroeconomicIndicator>`.

## Test plan

- [ ] Call `macroeconomic(indicator_code, ...)` and verify `info.periodicity` and `info.importance` are populated
- [ ] Verify all language bindings (Python, Node.js, Java) reflect the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)