### PR TITLE
chore: release 4.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.3] - 2026-06-26
+
 ### Added
 
 - **Rust:** `market::TradeStatus` models `/v1/quote/market-status` trade status codes, including engine-compatible normalization and display helpers.
@@ -13,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **All languages:** corrected market trade status documentation and aligned `market::TradeStatus` with the status definition table, including code `2001` and the `123`/`1009`/`1010` display names.
+- **All languages:** `macroeconomic` detail endpoint now populates `info.periodicity` and `info.importance` (`frequence`/`importance` fields added to `V2MacroIndicatorDetail`).
 
 ## [4.3.2] - 2026-06-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["rust", "python", "nodejs", "java", "c"]
 
 [workspace.package]
-version = "4.3.2"
+version = "4.3.3"
 edition = "2024"
 
 [profile.release]


### PR DESCRIPTION
## Summary

### Added
- **Rust:** `market::TradeStatus` models `/v1/quote/market-status` trade status codes, including engine-compatible normalization and display helpers

### Fixed
- **All languages:** corrected market trade status documentation and aligned `market::TradeStatus` with the status definition table, including code `2001` and the `123`/`1009`/`1010` display names
- **All languages:** `macroeconomic` detail endpoint now populates `info.periodicity` and `info.importance` (`frequence`/`importance` fields added to `V2MacroIndicatorDetail`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)