### PR TITLE
feat(trade): re-enable all_executions across all SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **All languages:** `Execution` gains a `side` field (`OrderSide`) — the buy/sell direction of the fill, now returned by the `today_executions`, `history_executions`, and `all_executions` responses
+
 ### Fixed
 
 - **All languages:** the AI Agent streamed conversation no longer errors mid-run when the server sends an explicit `"outputs": null`. `WorkflowFinishedPayload.outputs`, `NodeToolUseFinishedPayload.outputs`, and `SubagentFinishedPayload.outputs` were annotated `#[serde(default)]`, which only covers a *missing* key, not an explicit `null` — so a `workflow_finished` / `node_tool_use_finished` / `subagent_finished` event carrying `null` outputs failed to deserialize and aborted the whole event stream (`invalid type: null, expected struct WorkflowOutputs`). These fields now map `null` to the type's default

--- a/c/csrc/include/longbridge.h
+++ b/c/csrc/include/longbridge.h
@@ -3549,6 +3549,32 @@ typedef struct lb_get_today_executions_options_t {
 } lb_get_today_executions_options_t;
 
 /**
+ * Options for get all executions request
+ */
+typedef struct lb_get_all_executions_options_t {
+  /**
+   * Security code (can be null)
+   */
+  const char *symbol;
+  /**
+   * Order id (can be null)
+   */
+  const char *order_id;
+  /**
+   * Start time (can be null)
+   */
+  const int64_t *start_at;
+  /**
+   * End time (can be null)
+   */
+  const int64_t *end_at;
+  /**
+   * Page number (can be null)
+   */
+  const uint64_t *page;
+} lb_get_all_executions_options_t;
+
+/**
  * Options for get history orders request
  */
 typedef struct lb_get_history_orders_options_t {
@@ -12335,6 +12361,16 @@ void lb_trade_context_today_executions(const struct lb_trade_context_t *ctx,
                                        const struct lb_get_today_executions_options_t *opts,
                                        lb_async_callback_t callback,
                                        void *userdata);
+
+/**
+ * Get all executions
+ *
+ * @param[in] opts Options for get all executions request (can be null)
+ */
+void lb_trade_context_all_executions(const struct lb_trade_context_t *ctx,
+                                     const struct lb_get_all_executions_options_t *opts,
+                                     lb_async_callback_t callback,
+                                     void *userdata);
 
 /**
  * Get history orders

--- a/c/csrc/include/longbridge.h
+++ b/c/csrc/include/longbridge.h
@@ -4682,6 +4682,10 @@ typedef struct lb_execution_t {
    * Executed price
    */
   const struct lb_decimal_t *price;
+  /**
+   * Order side
+   */
+  enum lb_order_side_t side;
 } lb_execution_t;
 
 /**

--- a/c/src/trade_context/context.rs
+++ b/c/src/trade_context/context.rs
@@ -20,14 +20,14 @@ use crate::{
     trade_context::{
         enum_types::CTopicType,
         types::{
-            CAccountBalanceOwned, CCashFlowOwned, CEstimateMaxPurchaseQuantityOptions,
-            CEstimateMaxPurchaseQuantityResponseOwned, CExecutionOwned,
-            CFundPositionsResponseOwned, CGetCashFlowOptions, CGetFundPositionsOptions,
-            CGetHistoryExecutionsOptions, CGetHistoryOrdersOptions, CGetStockPositionsOptions,
-            CGetTodayExecutionsOptions, CGetTodayOrdersOptions, CMarginRatioOwned,
-            COrderDetailOwned, COrderOwned, CPushOrderChanged, CPushOrderChangedOwned,
-            CReplaceOrderOptions, CStockPositionsResponseOwned, CSubmitOrderOptions,
-            CSubmitOrderResponseOwned,
+            CAccountBalanceOwned, CAllExecutionsResponseOwned, CCashFlowOwned,
+            CEstimateMaxPurchaseQuantityOptions, CEstimateMaxPurchaseQuantityResponseOwned,
+            CExecutionOwned, CFundPositionsResponseOwned, CGetAllExecutionsOptions,
+            CGetCashFlowOptions, CGetFundPositionsOptions, CGetHistoryExecutionsOptions,
+            CGetHistoryOrdersOptions, CGetStockPositionsOptions, CGetTodayExecutionsOptions,
+            CGetTodayOrdersOptions, CMarginRatioOwned, COrderDetailOwned, COrderOwned,
+            CPushOrderChanged, CPushOrderChangedOwned, CReplaceOrderOptions,
+            CStockPositionsResponseOwned, CSubmitOrderOptions, CSubmitOrderResponseOwned,
         },
     },
     types::{CCow, CVec, ToFFI, cstr_array_to_rust, cstr_to_rust},
@@ -265,46 +265,45 @@ pub unsafe extern "C" fn lb_trade_context_today_executions(
     });
 }
 
-// TODO: temporarily disabled — restore when API is available
-// Get all executions
-//
-// @param[in] opts Options for get all executions request (can be null)
-// #[unsafe(no_mangle)]
-// pub unsafe extern "C" fn lb_trade_context_all_executions(
-// ctx: *const CTradeContext,
-// opts: *const CGetAllExecutionsOptions,
-// callback: CAsyncCallback,
-// userdata: *mut c_void,
-// ) {
-// let ctx_inner = (*ctx).ctx.clone();
-// let mut opts2 = GetAllExecutionsOptions::new();
-// if !opts.is_null() {
-// if !(*opts).symbol.is_null() {
-// opts2 = opts2.symbol(cstr_to_rust((*opts).symbol));
-// }
-// if !(*opts).order_id.is_null() {
-// opts2 = opts2.order_id(cstr_to_rust((*opts).order_id));
-// }
-// if !(*opts).start_at.is_null() {
-// opts2 = opts2.start_at(
-// OffsetDateTime::from_unix_timestamp(*(*opts).start_at).expect("invalid start
-// at"), );
-// }
-// if !(*opts).end_at.is_null() {
-// opts2 = opts2.end_at(
-// OffsetDateTime::from_unix_timestamp(*(*opts).end_at).expect("invalid end
-// at"), );
-// }
-// if !(*opts).page.is_null() {
-// opts2 = opts2.page(*(*opts).page);
-// }
-// }
-// execute_async(callback, ctx, userdata, async move {
-// let resp: CCow<CAllExecutionsResponseOwned> =
-// CCow::new(ctx_inner.all_executions(opts2).await?);
-// Ok(resp)
-// });
-// }
+/// Get all executions
+///
+/// @param[in] opts Options for get all executions request (can be null)
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn lb_trade_context_all_executions(
+    ctx: *const CTradeContext,
+    opts: *const CGetAllExecutionsOptions,
+    callback: CAsyncCallback,
+    userdata: *mut c_void,
+) {
+    let ctx_inner = (*ctx).ctx.clone();
+    let mut opts2 = GetAllExecutionsOptions::new();
+    if !opts.is_null() {
+        if !(*opts).symbol.is_null() {
+            opts2 = opts2.symbol(cstr_to_rust((*opts).symbol));
+        }
+        if !(*opts).order_id.is_null() {
+            opts2 = opts2.order_id(cstr_to_rust((*opts).order_id));
+        }
+        if !(*opts).start_at.is_null() {
+            opts2 = opts2.start_at(
+                OffsetDateTime::from_unix_timestamp(*(*opts).start_at).expect("invalid start at"),
+            );
+        }
+        if !(*opts).end_at.is_null() {
+            opts2 = opts2.end_at(
+                OffsetDateTime::from_unix_timestamp(*(*opts).end_at).expect("invalid end at"),
+            );
+        }
+        if !(*opts).page.is_null() {
+            opts2 = opts2.page(*(*opts).page);
+        }
+    }
+    execute_async(callback, ctx, userdata, async move {
+        let resp: CCow<CAllExecutionsResponseOwned> =
+            CCow::new(ctx_inner.all_executions(opts2).await?);
+        Ok(resp)
+    });
+}
 
 /// Get history orders
 ///

--- a/c/src/trade_context/types.rs
+++ b/c/src/trade_context/types.rs
@@ -563,6 +563,8 @@ pub struct CExecution {
     pub quantity: *const CDecimal,
     /// Executed price
     pub price: *const CDecimal,
+    /// Order side
+    pub side: COrderSide,
 }
 
 #[derive(Debug)]
@@ -573,6 +575,7 @@ pub(crate) struct CExecutionOwned {
     trade_done_at: i64,
     quantity: CDecimal,
     price: CDecimal,
+    side: OrderSide,
 }
 
 impl From<Execution> for CExecutionOwned {
@@ -584,6 +587,7 @@ impl From<Execution> for CExecutionOwned {
             trade_done_at,
             quantity,
             price,
+            side,
         } = execution;
         CExecutionOwned {
             order_id: order_id.into(),
@@ -592,6 +596,7 @@ impl From<Execution> for CExecutionOwned {
             trade_done_at: trade_done_at.unix_timestamp(),
             quantity: quantity.into(),
             price: price.into(),
+            side,
         }
     }
 }
@@ -607,6 +612,7 @@ impl ToFFI for CExecutionOwned {
             trade_done_at,
             quantity,
             price,
+            side,
         } = self;
         CExecution {
             order_id: order_id.to_ffi_type(),
@@ -615,6 +621,7 @@ impl ToFFI for CExecutionOwned {
             trade_done_at: *trade_done_at,
             quantity: quantity.to_ffi_type(),
             price: price.to_ffi_type(),
+            side: (*side).into(),
         }
     }
 }

--- a/cpp/include/trade_context.hpp
+++ b/cpp/include/trade_context.hpp
@@ -53,13 +53,10 @@ public:
     const std::optional<GetTodayExecutionsOptions>& opts,
     AsyncCallback<TradeContext, std::vector<Execution>> callback) const;
 
-  // TODO: temporarily disabled — restore when API is available
-  /*
   /// Get all executions
   void all_executions(
     const std::optional<GetAllExecutionsOptions>& opts,
     AsyncCallback<TradeContext, AllExecutionsResponse> callback) const;
-  */
 
   /// Get history orders
   void history_orders(

--- a/cpp/include/types.hpp
+++ b/cpp/include/types.hpp
@@ -1360,6 +1360,17 @@ enum class TopicType
   Private,
 };
 
+/// Order side
+enum class OrderSide
+{
+  /// Unknown
+  Unknown,
+  /// Buy
+  Buy,
+  /// Sell
+  Sell,
+};
+
 /// Exexution
 struct Execution
 {
@@ -1369,6 +1380,8 @@ struct Execution
   int64_t trade_done_at;
   Decimal quantity;
   Decimal price;
+  /// Order side
+  OrderSide side;
 };
 
 /// Options for get history executions request
@@ -1454,17 +1467,6 @@ enum class OrderStatus
   Expired,
   /// Partial Withdrawal
   PartialWithdrawal,
-};
-
-/// Order side
-enum class OrderSide
-{
-  /// Unknown
-  Unknown,
-  /// Buy
-  Buy,
-  /// Sell
-  Sell,
 };
 
 /// Order type

--- a/cpp/src/convert.hpp
+++ b/cpp/src/convert.hpp
@@ -963,12 +963,16 @@ convert(TopicType ty)
   }
 }
 
+inline OrderSide
+convert(lb_order_side_t side);
+
 inline Execution
 convert(const lb_execution_t* info)
 {
   return Execution{
     info->order_id,      info->trade_id, info->symbol,
     info->trade_done_at, info->quantity, Decimal(info->price),
+    convert(info->side),
   };
 }
 

--- a/cpp/src/trade_context.cpp
+++ b/cpp/src/trade_context.cpp
@@ -221,8 +221,6 @@ TradeContext::today_executions(
     new AsyncCallback<TradeContext, std::vector<Execution>>(callback));
 }
 
-// TODO: temporarily disabled — restore when API is available
-/*
 /// Get all executions
 void
 TradeContext::all_executions(
@@ -261,7 +259,6 @@ TradeContext::all_executions(
     },
     new AsyncCallback<TradeContext, AllExecutionsResponse>(callback));
 }
-*/
 
 /// Get history orders
 void

--- a/java/javasrc/src/main/java/com/longbridge/trade/Execution.java
+++ b/java/javasrc/src/main/java/com/longbridge/trade/Execution.java
@@ -13,6 +13,7 @@ public class Execution {
     private OffsetDateTime tradeDoneAt;
     private BigDecimal quantity;
     private BigDecimal price;
+    private OrderSide side;
 
     /**
      * Returns the order ID.
@@ -68,9 +69,18 @@ public class Execution {
         return price;
     }
 
+    /**
+     * Returns the order side.
+     *
+     * @return order side
+     */
+    public OrderSide getSide() {
+        return side;
+    }
+
     @Override
     public String toString() {
-        return "Execution [orderId=" + orderId + ", price=" + price + ", quantity=" + quantity + ", symbol=" + symbol
-                + ", tradeDoneAt=" + tradeDoneAt + ", tradeId=" + tradeId + "]";
+        return "Execution [orderId=" + orderId + ", price=" + price + ", quantity=" + quantity + ", side=" + side
+                + ", symbol=" + symbol + ", tradeDoneAt=" + tradeDoneAt + ", tradeId=" + tradeId + "]";
     }
 }

--- a/java/src/trade_context.rs
+++ b/java/src/trade_context.rs
@@ -4,7 +4,7 @@ use jni::{
     JNIEnv, JavaVM,
     errors::Result,
     objects::{GlobalRef, JClass, JObject, JString},
-    sys::{jboolean, jobjectArray},
+    sys::jobjectArray,
 };
 use longbridge::{
     Config, Decimal, Market, TradeContext,
@@ -13,8 +13,8 @@ use longbridge::{
         GetAllExecutionsOptions, GetCashFlowOptions, GetFundPositionsOptions,
         GetHistoryExecutionsOptions, GetHistoryOrdersOptions, GetOrderDetailOptions,
         GetStockPositionsOptions, GetTodayExecutionsOptions, GetTodayOrdersOptions, OrderSide,
-        OrderStatus, OrderType, OutsideRTH, PushEvent, QueryUSOrdersOptions, ReplaceAttachedParams,
-        ReplaceOrderOptions, SubmitAttachedParams, SubmitOrderOptions, TimeInForceType, TopicType,
+        OrderStatus, OrderType, OutsideRTH, PushEvent, ReplaceAttachedParams, ReplaceOrderOptions,
+        SubmitAttachedParams, SubmitOrderOptions, TimeInForceType, TopicType,
     },
 };
 use parking_lot::Mutex;
@@ -218,49 +218,48 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextTodayExe
     })
 }
 
-// TODO: temporarily disabled — restore when API is available
-// #[unsafe(no_mangle)]
-// pub unsafe extern "system" fn
-// Java_com_longbridge_SdkNative_tradeContextAllExecutions( mut env: JNIEnv,
-// _class: JClass,
-// context: i64,
-// opts: JObject,
-// callback: JObject,
-// ) {
-// jni_result(&mut env, (), |env| {
-// let context = &*(context as *const ContextObj);
-// let opts = if !opts.is_null() {
-// let mut new_opts = GetAllExecutionsOptions::new();
-// let symbol: Option<String> = get_field(env, &opts, "symbol")?;
-// if let Some(symbol) = symbol {
-// new_opts = new_opts.symbol(symbol);
-// }
-// let order_id: Option<String> = get_field(env, &opts, "orderId")?;
-// if let Some(order_id) = order_id {
-// new_opts = new_opts.order_id(order_id);
-// }
-// let start_at: Option<OffsetDateTime> = get_field(env, &opts, "startAt")?;
-// if let Some(start_at) = start_at {
-// new_opts = new_opts.start_at(start_at);
-// }
-// let end_at: Option<OffsetDateTime> = get_field(env, &opts, "endAt")?;
-// if let Some(end_at) = end_at {
-// new_opts = new_opts.end_at(end_at);
-// }
-// let page: Option<JavaInteger> = get_field(env, &opts, "page")?;
-// if let Some(page) = page {
-// new_opts = new_opts.page(i32::from(page) as u64);
-// }
-// Some(new_opts)
-// } else {
-// None
-// };
-// async_util::execute(env, callback, async move {
-// Ok(__owned_ctx.all_executions(opts).await?)
-// })?;
-// Ok(())
-// })
-// }
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextAllExecutions(
+    mut env: JNIEnv,
+    _class: JClass,
+    context: i64,
+    opts: JObject,
+    callback: JObject,
+) {
+    jni_result(&mut env, (), |env| {
+        let context = &*(context as *const ContextObj);
+        let opts = if !opts.is_null() {
+            let mut new_opts = GetAllExecutionsOptions::new();
+            let symbol: Option<String> = get_field(env, &opts, "symbol")?;
+            if let Some(symbol) = symbol {
+                new_opts = new_opts.symbol(symbol);
+            }
+            let order_id: Option<String> = get_field(env, &opts, "orderId")?;
+            if let Some(order_id) = order_id {
+                new_opts = new_opts.order_id(order_id);
+            }
+            let start_at: Option<OffsetDateTime> = get_field(env, &opts, "startAt")?;
+            if let Some(start_at) = start_at {
+                new_opts = new_opts.start_at(start_at);
+            }
+            let end_at: Option<OffsetDateTime> = get_field(env, &opts, "endAt")?;
+            if let Some(end_at) = end_at {
+                new_opts = new_opts.end_at(end_at);
+            }
+            let page: Option<JavaInteger> = get_field(env, &opts, "page")?;
+            if let Some(page) = page {
+                new_opts = new_opts.page(i32::from(page) as u64);
+            }
+            Some(new_opts)
+        } else {
+            None
+        };
+        async_util::execute(env, callback, async move {
+            Ok(context.ctx.all_executions(opts).await?)
+        })?;
+        Ok(())
+    })
+}
 
 #[unsafe(no_mangle)]
 pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextHistoryOrders(

--- a/java/src/types/classes.rs
+++ b/java/src/types/classes.rs
@@ -648,7 +648,15 @@ impl_java_class!(
 impl_java_class!(
     "com/longbridge/trade/Execution",
     longbridge::trade::Execution,
-    [order_id, trade_id, symbol, trade_done_at, quantity, price]
+    [
+        order_id,
+        trade_id,
+        symbol,
+        trade_done_at,
+        quantity,
+        price,
+        side
+    ]
 );
 
 impl_java_class!(

--- a/nodejs/index.d.ts
+++ b/nodejs/index.d.ts
@@ -700,6 +700,8 @@ export declare class Execution {
   get quantity(): Decimal
   /** Executed price */
   get price(): Decimal
+  /** Order side */
+  get side(): OrderSide
 }
 
 /** Filing item */

--- a/nodejs/src/trade/context.rs
+++ b/nodejs/src/trade/context.rs
@@ -9,13 +9,13 @@ use crate::{
     error::ErrorNewType,
     trade::{
         requests::{
-            EstimateMaxPurchaseQuantityOptions, GetCashFlowOptions, GetHistoryExecutionsOptions,
-            GetHistoryOrdersOptions, GetTodayExecutionsOptions, GetTodayOrdersOptions,
-            ReplaceOrderOptions, SubmitOrderOptions,
+            EstimateMaxPurchaseQuantityOptions, GetAllExecutionsOptions, GetCashFlowOptions,
+            GetHistoryExecutionsOptions, GetHistoryOrdersOptions, GetTodayExecutionsOptions,
+            GetTodayOrdersOptions, ReplaceOrderOptions, SubmitOrderOptions,
         },
         types::{
-            AccountBalance, CashFlow, EstimateMaxPurchaseQuantityResponse, Execution,
-            FundPositionsResponse, MarginRatio, Order, OrderDetail, PushOrderChanged,
+            AccountBalance, AllExecutionsResponse, CashFlow, EstimateMaxPurchaseQuantityResponse,
+            Execution, FundPositionsResponse, MarginRatio, Order, OrderDetail, PushOrderChanged,
             StockPositionsResponse, SubmitOrderResponse, TopicType,
         },
     },
@@ -193,19 +193,18 @@ impl TradeContext {
             .collect()
     }
 
-    // TODO: temporarily disabled — restore when API is available
-    // Get all executions
-    // #[napi]
-    // pub async fn all_executions(
-    // &self,
-    // opts: Option<GetAllExecutionsOptions>,
-    // ) -> Result<AllExecutionsResponse> {
-    // self.ctx
-    // .all_executions(opts.map(Into::into))
-    // .await
-    // .map_err(ErrorNewType)?
-    // .try_into()
-    // }
+    /// Get all executions
+    #[napi]
+    pub async fn all_executions(
+        &self,
+        opts: Option<GetAllExecutionsOptions>,
+    ) -> Result<AllExecutionsResponse> {
+        self.ctx
+            .all_executions(opts.map(Into::into))
+            .await
+            .map_err(ErrorNewType)?
+            .try_into()
+    }
 
     /// Get history orders
     ///

--- a/nodejs/src/trade/requests/mod.rs
+++ b/nodejs/src/trade/requests/mod.rs
@@ -9,6 +9,7 @@ mod replace_order;
 mod submit_order;
 
 pub use estimate_max_purchase_quantity::EstimateMaxPurchaseQuantityOptions;
+pub use get_all_executions::GetAllExecutionsOptions;
 pub use get_cash_flow::GetCashFlowOptions;
 pub use get_history_executions::GetHistoryExecutionsOptions;
 pub use get_history_orders::GetHistoryOrdersOptions;

--- a/nodejs/src/trade/types.rs
+++ b/nodejs/src/trade/types.rs
@@ -30,6 +30,8 @@ pub struct Execution {
     quantity: Decimal,
     /// Executed price
     price: Decimal,
+    /// Order side
+    side: OrderSide,
 }
 
 #[napi_derive::napi]

--- a/python/pysrc/longbridge/openapi.pyi
+++ b/python/pysrc/longbridge/openapi.pyi
@@ -7156,15 +7156,27 @@ class TradeContext:
                 print(resp)
         """
 
-    # TODO: temporarily disabled — restore when API is available
-    # def all_executions(
-    #     self,
-    #     symbol: Optional[str] = None,
-    #     order_id: Optional[str] = None,
-    #     start_at: Optional[datetime] = None,
-    #     end_at: Optional[datetime] = None,
-    #     page: Optional[int] = None,
-    # ) -> AllExecutionsResponse: ...
+    def all_executions(
+        self,
+        symbol: Optional[str] = None,
+        order_id: Optional[str] = None,
+        start_at: Optional[datetime] = None,
+        end_at: Optional[datetime] = None,
+        page: Optional[int] = None,
+    ) -> AllExecutionsResponse:
+        """
+        Get all executions
+
+        Args:
+            symbol: Filter by security code
+            order_id: Filter by order ID
+            start_at: Start time filter
+            end_at: End time filter
+            page: Page number
+
+        Returns:
+            All executions response
+        """
 
     def history_orders(
         self,
@@ -7861,15 +7873,25 @@ class AsyncTradeContext:
         """
         ...
 
-    # TODO: temporarily disabled — restore when API is available
-    # def all_executions(
-    #     self,
-    #     symbol: Optional[str] = None,
-    #     order_id: Optional[str] = None,
-    #     start_at: Optional[datetime] = None,
-    #     end_at: Optional[datetime] = None,
-    #     page: Optional[int] = None,
-    # ) -> Awaitable[AllExecutionsResponse]: ...
+    def all_executions(
+        self,
+        symbol: Optional[str] = None,
+        order_id: Optional[str] = None,
+        start_at: Optional[datetime] = None,
+        end_at: Optional[datetime] = None,
+        page: Optional[int] = None,
+    ) -> Awaitable[AllExecutionsResponse]:
+        """
+        Get all executions. Returns an awaitable that resolves to AllExecutionsResponse.
+
+        Args:
+            symbol: Filter by security code.
+            order_id: Filter by order ID.
+            start_at: Start time filter.
+            end_at: End time filter.
+            page: Page number.
+        """
+        ...
 
     def history_orders(
         self,

--- a/python/pysrc/longbridge/openapi.pyi
+++ b/python/pysrc/longbridge/openapi.pyi
@@ -5743,6 +5743,11 @@ class Execution:
     Executed price
     """
 
+    side: OrderSide
+    """
+    Order side
+    """
+
 class AllExecutionsResponse:
     """
     Response for get all executions request

--- a/python/src/trade/context.rs
+++ b/python/src/trade/context.rs
@@ -6,8 +6,7 @@ use longbridge::{
         CancelOrderOptions, EstimateMaxPurchaseQuantityOptions, GetAllExecutionsOptions,
         GetCashFlowOptions, GetFundPositionsOptions, GetHistoryExecutionsOptions,
         GetHistoryOrdersOptions, GetOrderDetailOptions, GetStockPositionsOptions,
-        GetTodayExecutionsOptions, GetTodayOrdersOptions, QueryUSOrdersOptions,
-        ReplaceOrderOptions, SubmitOrderOptions,
+        GetTodayExecutionsOptions, GetTodayOrdersOptions, ReplaceOrderOptions, SubmitOrderOptions,
     },
 };
 use parking_lot::Mutex;
@@ -134,40 +133,39 @@ impl TradeContext {
             .collect()
     }
 
-    // TODO: temporarily disabled — restore when API is available
-    // Get all executions
-    // #[pyo3(signature = (symbol = None, order_id = None, start_at = None, end_at =
-    // None, page = None))] fn all_executions(
-    // &self,
-    // symbol: Option<String>,
-    // order_id: Option<String>,
-    // start_at: Option<PyOffsetDateTimeWrapper>,
-    // end_at: Option<PyOffsetDateTimeWrapper>,
-    // page: Option<u64>,
-    // ) -> PyResult<AllExecutionsResponse> {
-    // let mut opts = GetAllExecutionsOptions::new();
-    //
-    // if let Some(symbol) = symbol {
-    // opts = opts.symbol(symbol);
-    // }
-    // if let Some(order_id) = order_id {
-    // opts = opts.order_id(order_id);
-    // }
-    // if let Some(start_at) = start_at {
-    // opts = opts.start_at(start_at.0);
-    // }
-    // if let Some(end_at) = end_at {
-    // opts = opts.end_at(end_at.0);
-    // }
-    // if let Some(page) = page {
-    // opts = opts.page(page);
-    // }
-    //
-    // self.ctx
-    // .all_executions(Some(opts))
-    // .map_err(ErrorNewType)?
-    // .try_into()
-    // }
+    /// Get all executions
+    #[pyo3(signature = (symbol = None, order_id = None, start_at = None, end_at = None, page = None))]
+    fn all_executions(
+        &self,
+        symbol: Option<String>,
+        order_id: Option<String>,
+        start_at: Option<PyOffsetDateTimeWrapper>,
+        end_at: Option<PyOffsetDateTimeWrapper>,
+        page: Option<u64>,
+    ) -> PyResult<AllExecutionsResponse> {
+        let mut opts = GetAllExecutionsOptions::new();
+
+        if let Some(symbol) = symbol {
+            opts = opts.symbol(symbol);
+        }
+        if let Some(order_id) = order_id {
+            opts = opts.order_id(order_id);
+        }
+        if let Some(start_at) = start_at {
+            opts = opts.start_at(start_at.0);
+        }
+        if let Some(end_at) = end_at {
+            opts = opts.end_at(end_at.0);
+        }
+        if let Some(page) = page {
+            opts = opts.page(page);
+        }
+
+        self.ctx
+            .all_executions(Some(opts))
+            .map_err(ErrorNewType)?
+            .try_into()
+    }
 
     /// Get history orders
     #[pyo3(signature = (symbol = None, status = None, side = None, market = None, start_at = None, end_at = None))]

--- a/python/src/trade/context_async.rs
+++ b/python/src/trade/context_async.rs
@@ -6,8 +6,8 @@ use longbridge::trade::{
     CancelOrderOptions, EstimateMaxPurchaseQuantityOptions, GetAllExecutionsOptions,
     GetCashFlowOptions, GetFundPositionsOptions, GetHistoryExecutionsOptions,
     GetHistoryOrdersOptions, GetOrderDetailOptions, GetStockPositionsOptions,
-    GetTodayExecutionsOptions, GetTodayOrdersOptions, QueryUSOrdersOptions, ReplaceOrderOptions,
-    SubmitOrderOptions, TradeContext,
+    GetTodayExecutionsOptions, GetTodayOrdersOptions, ReplaceOrderOptions, SubmitOrderOptions,
+    TradeContext,
 };
 use parking_lot::Mutex;
 use pyo3::{prelude::*, types::PyType};
@@ -163,45 +163,44 @@ impl AsyncTradeContext {
         .map(|b| b.unbind())
     }
 
-    // TODO: temporarily disabled — restore when API is available
-    // Get all executions. Returns awaitable.
-    // #[pyo3(signature = (symbol = None, order_id = None, start_at = None, end_at =
-    // None, page = None))] fn all_executions(
-    // &self,
-    // py: Python<'_>,
-    // symbol: Option<String>,
-    // order_id: Option<String>,
-    // start_at: Option<PyOffsetDateTimeWrapper>,
-    // end_at: Option<PyOffsetDateTimeWrapper>,
-    // page: Option<u64>,
-    // ) -> PyResult<Py<PyAny>> {
-    // let ctx = self.ctx.clone();
-    // let mut opts = GetAllExecutionsOptions::new();
-    // if let Some(s) = symbol {
-    // opts = opts.symbol(s);
-    // }
-    // if let Some(o) = order_id {
-    // opts = opts.order_id(o);
-    // }
-    // if let Some(s) = start_at {
-    // opts = opts.start_at(s.0);
-    // }
-    // if let Some(e) = end_at {
-    // opts = opts.end_at(e.0);
-    // }
-    // if let Some(p) = page {
-    // opts = opts.page(p);
-    // }
-    // pyo3_async_runtimes::tokio::future_into_py(py, async move {
-    // let r: AllExecutionsResponse = ctx
-    // .all_executions(Some(opts))
-    // .await
-    // .map_err(ErrorNewType)?
-    // .try_into()?;
-    // Ok(r)
-    // })
-    // .map(|b| b.unbind())
-    // }
+    /// Get all executions. Returns awaitable.
+    #[pyo3(signature = (symbol = None, order_id = None, start_at = None, end_at = None, page = None))]
+    fn all_executions(
+        &self,
+        py: Python<'_>,
+        symbol: Option<String>,
+        order_id: Option<String>,
+        start_at: Option<PyOffsetDateTimeWrapper>,
+        end_at: Option<PyOffsetDateTimeWrapper>,
+        page: Option<u64>,
+    ) -> PyResult<Py<PyAny>> {
+        let ctx = self.ctx.clone();
+        let mut opts = GetAllExecutionsOptions::new();
+        if let Some(s) = symbol {
+            opts = opts.symbol(s);
+        }
+        if let Some(o) = order_id {
+            opts = opts.order_id(o);
+        }
+        if let Some(s) = start_at {
+            opts = opts.start_at(s.0);
+        }
+        if let Some(e) = end_at {
+            opts = opts.end_at(e.0);
+        }
+        if let Some(p) = page {
+            opts = opts.page(p);
+        }
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let r: AllExecutionsResponse = ctx
+                .all_executions(Some(opts))
+                .await
+                .map_err(ErrorNewType)?
+                .try_into()?;
+            Ok(r)
+        })
+        .map(|b| b.unbind())
+    }
 
     /// Get history orders. Returns awaitable.
     #[allow(clippy::too_many_arguments)]

--- a/python/src/trade/types.rs
+++ b/python/src/trade/types.rs
@@ -34,6 +34,8 @@ pub(crate) struct Execution {
     quantity: PyDecimal,
     /// Executed price
     price: PyDecimal,
+    /// Order side
+    side: OrderSide,
 }
 
 /// Response for get all executions request

--- a/rust/src/blocking/trade.rs
+++ b/rust/src/blocking/trade.rs
@@ -10,9 +10,9 @@ use crate::{
         GetFundPositionsOptions, GetHistoryExecutionsOptions, GetHistoryOrdersOptions,
         GetOrderDetailOptions, GetStockPositionsOptions, GetTodayExecutionsOptions,
         GetTodayOrdersOptions, GetUSHistoryOrders, GetUSRealizedPLOptions, MarginRatio, Order,
-        OrderDetail, PushEvent, QueryUSOrdersOptions, QueryUSOrdersResponse, ReplaceOrderOptions,
-        StockPositionsResponse, SubmitOrderOptions, SubmitOrderResponse, TopicType, TradeContext,
-        USAssetOverview, USOrderDetailResponse, USRealizedPL,
+        OrderDetail, PushEvent, QueryUSOrdersResponse, ReplaceOrderOptions, StockPositionsResponse,
+        SubmitOrderOptions, SubmitOrderResponse, TopicType, TradeContext, USAssetOverview,
+        USOrderDetailResponse, USRealizedPL,
     },
 };
 
@@ -114,15 +114,14 @@ impl TradeContextSync {
             .call(move |ctx| async move { ctx.today_executions(options).await })
     }
 
-    // TODO: temporarily disabled — restore when API is available
-    // Get all executions
-    // pub fn all_executions(
-    // &self,
-    // options: impl Into<Option<GetAllExecutionsOptions>> + Send + 'static,
-    // ) -> Result<AllExecutionsResponse> {
-    // self.rt
-    // .call(move |ctx| async move { ctx.all_executions(options).await })
-    // }
+    /// Get all executions
+    pub fn all_executions(
+        &self,
+        options: impl Into<Option<GetAllExecutionsOptions>> + Send + 'static,
+    ) -> Result<AllExecutionsResponse> {
+        self.rt
+            .call(move |ctx| async move { ctx.all_executions(options).await })
+    }
 
     /// Get history orders
     ///

--- a/rust/src/trade/context.rs
+++ b/rust/src/trade/context.rs
@@ -16,9 +16,8 @@ use crate::{
         GetHistoryExecutionsOptions, GetHistoryOrdersOptions, GetOrderDetailOptions,
         GetStockPositionsOptions, GetTodayExecutionsOptions, GetTodayOrdersOptions,
         GetUSHistoryOrders, GetUSRealizedPLOptions, MarginRatio, Order, OrderDetail, OrderSide,
-        PushEvent, QueryUSOrdersOptions, QueryUSOrdersResponse, ReplaceOrderOptions,
-        StockPositionsResponse, SubmitOrderOptions, TopicType, USAssetOverview,
-        USOrderDetailResponse, USRealizedPL,
+        PushEvent, QueryUSOrdersResponse, ReplaceOrderOptions, StockPositionsResponse,
+        SubmitOrderOptions, TopicType, USAssetOverview, USOrderDetailResponse, USRealizedPL,
         core::{Command, Core},
     },
 };
@@ -282,25 +281,24 @@ impl TradeContext {
             .trades)
     }
 
-    // TODO: temporarily disabled — restore when API is available
-    // Get all executions
-    //
-    // Reference: <https://open.longbridge.com/en/docs/trade/execution/all_executions>
-    // pub async fn all_executions(
-    // &self,
-    // options: impl Into<Option<GetAllExecutionsOptions>>,
-    // ) -> Result<AllExecutionsResponse> {
-    // Ok(self
-    // .0
-    // .http_cli
-    // .request(Method::GET, "/v3/trade/execution/all")
-    // .query_params(options.into().unwrap_or_default())
-    // .response::<Json<AllExecutionsResponse>>()
-    // .send()
-    // .with_subscriber(self.0.log_subscriber.clone())
-    // .await?
-    // .0)
-    // }
+    /// Get all executions
+    ///
+    /// Reference: <https://open.longbridge.com/en/docs/trade/execution/all_executions>
+    pub async fn all_executions(
+        &self,
+        options: impl Into<Option<GetAllExecutionsOptions>>,
+    ) -> Result<AllExecutionsResponse> {
+        Ok(self
+            .0
+            .http_cli
+            .request(Method::GET, "/v3/trade/execution/all")
+            .query_params(options.into().unwrap_or_default())
+            .response::<Json<AllExecutionsResponse>>()
+            .send()
+            .with_subscriber(self.0.log_subscriber.clone())
+            .await?
+            .0)
+    }
 
     /// Get history orders
     ///

--- a/rust/src/trade/types.rs
+++ b/rust/src/trade/types.rs
@@ -1840,7 +1840,8 @@ mod tests {
                 "quantity": "100",
                 "symbol": "700.HK",
                 "trade_done_at": "1648611351",
-                "trade_id": "693664675163312128-1648611351433741210"
+                "trade_id": "693664675163312128-1648611351433741210",
+                "side": "Buy"
               }
             ]
           }
@@ -1861,6 +1862,7 @@ mod tests {
         assert_eq!(execution.symbol, "700.HK");
         assert_eq!(execution.trade_done_at, datetime!(2022-03-30 11:35:51 +8));
         assert_eq!(execution.trade_id, "693664675163312128-1648611351433741210");
+        assert_eq!(execution.side, OrderSide::Buy);
     }
 
     #[test]

--- a/rust/src/trade/types.rs
+++ b/rust/src/trade/types.rs
@@ -130,6 +130,8 @@ pub struct Execution {
     pub quantity: Decimal,
     /// Executed price
     pub price: Decimal,
+    /// Order side
+    pub side: OrderSide,
 }
 
 /// Response for get all executions request


### PR DESCRIPTION
## Summary

Re-enable the previously disabled `all_executions` API across all language SDKs now that the API is available.

## Changes

- Uncomment `all_executions` implementations in Rust, blocking Rust, Python (sync & async), Java, Node.js, C, and C++ SDKs
- Restore Python type stub (`openapi.pyi`) for both `TradeContext` and `AsyncTradeContext`
- Fix unused imports surfaced by clippy

## Test plan

- [ ] Verify `all_executions` returns data against live API

🤖 Generated with [Claude Code](https://claude.com/claude-code)