### PR TITLE
fix(java): make native handle lifetimes safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,9 @@ jobs:
       - name: Check with clippy
         run: cargo clippy -p longbridge-java --all-features
 
+      - name: Test native library
+        run: cargo test -p longbridge-java --all-features
+
       - name: Compile java sources
         working-directory: java/javasrc
         run: mvn package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Java SDK:** prevent native crashes when contexts or other SDK handles are closed more than once or while asynchronous operations are still in flight
+- **Java SDK:** prevent native crashes when contexts or other SDK handles are closed more than once or while asynchronous operations are still in flight, with native lifecycle regression tests running in CI
 
 ## [4.4.3] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **All languages:** add optional `parent_message_id` parameter to the AI Agent `conversation` and `conversation_streamed` methods — pass the `message_id` from a previous response to attach a follow-up message after the specified one, keeping the message stream in order. Only valid together with `chat_uid`; must not be set for a new conversation
 
+### Fixed
+
+- **Java SDK:** prevent native crashes when contexts or other SDK handles are closed more than once or while asynchronous operations are still in flight
+
 ## [4.4.3] - 2026-07-30
 
 ### Fixed

--- a/java/src/agent_context.rs
+++ b/java/src/agent_context.rs
@@ -76,7 +76,7 @@ fn new_subscription_object<'a>(
     env.new_object(cls, "(J)V", &[JValue::from(handle)])
 }
 
-/// Finish a successful `subscribe()`: box up `subscription` behind an opaque
+/// Finish a successful `subscribe()`: store `subscription` behind an opaque
 /// handle, wrap it in a Java `ConversationStreamSubscription`, and deliver it
 /// via `onSubscribe`. If attaching to the JVM or constructing the Java object
 /// fails, the boxed subscription is freed immediately so it isn't leaked (the
@@ -86,12 +86,10 @@ fn finish_subscribe_success(
     sink: Arc<SubscriberSink>,
     subscription: agent::ConversationStreamSubscription,
 ) {
-    let handle = Box::into_raw(Box::new(subscription)) as i64;
+    let handle = crate::handles::insert(subscription);
 
     let Ok(mut env) = sink.jvm.attach_current_thread() else {
-        unsafe {
-            let _ = Box::from_raw(handle as *mut agent::ConversationStreamSubscription);
-        }
+        crate::handles::remove(handle);
         return;
     };
 
@@ -104,9 +102,7 @@ fn finish_subscribe_success(
                 &[JValue::from(&obj)],
             );
         }
-        Err(_) => unsafe {
-            let _ = Box::from_raw(handle as *mut agent::ConversationStreamSubscription);
-        },
+        Err(_) => crate::handles::remove(handle),
     }
 }
 
@@ -141,10 +137,10 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newAgentContext(
     config: i64,
 ) -> i64 {
     jni_result(&mut env, 0i64, |_env| {
-        let config = Arc::new((*(config as *const Config)).clone());
-        Ok(Box::into_raw(Box::new(ContextObj {
+        let config = crate::handles::get::<Config>(config)?;
+        Ok(crate::handles::insert(ContextObj {
             ctx: AgentContext::new(config),
-        })) as i64)
+        }))
     })
 }
 
@@ -154,7 +150,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeAgentContext(
     _class: JClass,
     ctx: i64,
 ) {
-    let _ = Box::from_raw(ctx as *mut ContextObj);
+    crate::handles::remove(ctx);
 }
 
 #[unsafe(no_mangle)]
@@ -165,7 +161,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_agentContextWorkspac
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(
             env,
             callback,
@@ -185,7 +181,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_agentContextAgents(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let workspace_id: String = FromJValue::from_jvalue(env, workspace_id.into())?;
         let opts = read_get_agents_options(env, &opts)?;
         async_util::execute(env, callback, async move {
@@ -207,7 +203,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_agentContextConversa
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let agent_id: String = FromJValue::from_jvalue(env, agent_id.into())?;
         let query: String = FromJValue::from_jvalue(env, query.into())?;
         let chat_uid: Option<String> = FromJValue::from_jvalue(env, chat_uid.into())?;
@@ -237,7 +233,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_agentContextContinue
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let agent_id: String = FromJValue::from_jvalue(env, agent_id.into())?;
         let chat_uid: String = FromJValue::from_jvalue(env, chat_uid.into())?;
         let message_id: String = FromJValue::from_jvalue(env, message_id.into())?;
@@ -267,7 +263,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_agentContextConversa
     subscriber: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let ctx = context.ctx.clone();
         let agent_id: String = FromJValue::from_jvalue(env, agent_id.into())?;
         let query: String = FromJValue::from_jvalue(env, query.into())?;
@@ -317,7 +313,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_agentContextContinue
     subscriber: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let ctx = context.ctx.clone();
         let agent_id: String = FromJValue::from_jvalue(env, agent_id.into())?;
         let chat_uid: String = FromJValue::from_jvalue(env, chat_uid.into())?;
@@ -353,23 +349,29 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_agentContextContinue
 
 #[unsafe(no_mangle)]
 pub unsafe extern "system" fn Java_com_longbridge_SdkNative_conversationStreamSubscriptionRequest(
-    _env: JNIEnv,
+    mut env: JNIEnv,
     _class: JClass,
     handle: i64,
     n: i64,
 ) {
-    let subscription = &*(handle as *const agent::ConversationStreamSubscription);
-    subscription.request(n.max(0) as u64);
+    jni_result(&mut env, (), |_env| {
+        let subscription = crate::handles::get::<agent::ConversationStreamSubscription>(handle)?;
+        subscription.request(n.max(0) as u64);
+        Ok(())
+    });
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "system" fn Java_com_longbridge_SdkNative_conversationStreamSubscriptionCancel(
-    _env: JNIEnv,
+    mut env: JNIEnv,
     _class: JClass,
     handle: i64,
 ) {
-    let subscription = &*(handle as *const agent::ConversationStreamSubscription);
-    subscription.cancel();
+    jni_result(&mut env, (), |_env| {
+        let subscription = crate::handles::get::<agent::ConversationStreamSubscription>(handle)?;
+        subscription.cancel();
+        Ok(())
+    });
 }
 
 #[unsafe(no_mangle)]
@@ -378,5 +380,5 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeConversationStre
     _class: JClass,
     handle: i64,
 ) {
-    let _ = Box::from_raw(handle as *mut agent::ConversationStreamSubscription);
+    crate::handles::remove(handle);
 }

--- a/java/src/alert_context.rs
+++ b/java/src/alert_context.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use jni::{
     JNIEnv,
     objects::{JClass, JObject},
@@ -61,10 +59,10 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newAlertContext(
     config: i64,
 ) -> i64 {
     jni_result(&mut env, 0i64, |_env| {
-        let config = Arc::new((*(config as *const Config)).clone());
-        Ok(Box::into_raw(Box::new(ContextObj {
+        let config = crate::handles::get::<Config>(config)?;
+        Ok(crate::handles::insert(ContextObj {
             ctx: AlertContext::new(config),
-        })) as i64)
+        }))
     })
 }
 #[unsafe(no_mangle)]
@@ -73,7 +71,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeAlertContext(
     _class: JClass,
     ctx: i64,
 ) {
-    let _ = Box::from_raw(ctx as *mut ContextObj);
+    crate::handles::remove(ctx);
 }
 
 #[unsafe(no_mangle)]
@@ -84,7 +82,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_alertContextList(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move { Ok(context.ctx.list().await?) })?;
         Ok(())
     })
@@ -99,7 +97,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_alertContextAdd(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = get_field(env, &opts, "symbol")?;
         let condition: Option<AlertCondition> = get_field(env, &opts, "condition")?;
         let condition = condition.unwrap_or(AlertCondition::PriceRise);
@@ -126,7 +124,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_alertContextUpdate(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let alert_item = read_alert_item(env, &item)?;
         async_util::execute(env, callback, async move {
             context.ctx.update(&alert_item).await?;
@@ -145,7 +143,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_alertContextDelete(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let ids_raw: ObjectArray<String> = get_field(env, &opts, "ids")?;
         let ids: Vec<String> = ids_raw.0;
         async_util::execute(env, callback, async move {

--- a/java/src/asset_context.rs
+++ b/java/src/asset_context.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use jni::{
     JNIEnv,
     objects::{JClass, JObject},
@@ -26,9 +24,9 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newAssetContext(
     config: i64,
 ) -> i64 {
     jni_result(&mut env, 0i64, |_env| {
-        let config = Arc::new((*(config as *const Config)).clone());
+        let config = crate::handles::get::<Config>(config)?;
         let ctx = AssetContext::new(config);
-        Ok(Box::into_raw(Box::new(ContextObj { ctx })) as i64)
+        Ok(crate::handles::insert(ContextObj { ctx }))
     })
 }
 
@@ -38,7 +36,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeAssetContext(
     _class: JClass,
     ctx: i64,
 ) {
-    let _ = Box::from_raw(ctx as *mut ContextObj);
+    crate::handles::remove(ctx);
 }
 
 #[unsafe(no_mangle)]
@@ -50,7 +48,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_assetContextStatemen
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let statement_type: Option<JavaInteger> = get_field(env, &opts, "statementType")?;
         let start_date: Option<JavaInteger> = get_field(env, &opts, "startDate")?;
         let limit: Option<JavaInteger> = get_field(env, &opts, "limit")?;
@@ -84,7 +82,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_assetContextDownload
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let file_key: String = FromJValue::from_jvalue(env, file_key.into())?;
         let options = GetStatementOptions::new(file_key);
 

--- a/java/src/calendar_context.rs
+++ b/java/src/calendar_context.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use jni::{
     JNIEnv,
     objects::{JClass, JObject},
@@ -19,10 +17,10 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newCalendarContext(
     config: i64,
 ) -> i64 {
     jni_result(&mut env, 0i64, |_env| {
-        let config = Arc::new((*(config as *const Config)).clone());
-        Ok(Box::into_raw(Box::new(ContextObj {
+        let config = crate::handles::get::<Config>(config)?;
+        Ok(crate::handles::insert(ContextObj {
             ctx: CalendarContext::new(config),
-        })) as i64)
+        }))
     })
 }
 
@@ -32,7 +30,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeCalendarContext(
     _class: JClass,
     ctx: i64,
 ) {
-    let _ = Box::from_raw(ctx as *mut ContextObj);
+    crate::handles::remove(ctx);
 }
 
 #[unsafe(no_mangle)]
@@ -44,7 +42,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_calendarContextFinan
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let category: Option<CalendarCategory> = get_field(env, &opts, "category")?;
         let category = category.unwrap_or(CalendarCategory::Report);
         let start: String = get_field(env, &opts, "start")?;

--- a/java/src/config.rs
+++ b/java/src/config.rs
@@ -24,7 +24,7 @@ pub extern "system" fn Java_com_longbridge_SdkNative_newConfigFromApikey(
         let app_secret = String::from_jvalue(env, app_secret.into())?;
         let access_token = String::from_jvalue(env, access_token.into())?;
         let config = Config::from_apikey(app_key, app_secret, access_token);
-        Ok(Box::into_raw(Box::new(config)) as jlong)
+        Ok(crate::handles::insert(config))
     })
 }
 
@@ -35,7 +35,7 @@ pub extern "system" fn Java_com_longbridge_SdkNative_newConfigFromApikeyEnv(
 ) -> jlong {
     jni_result(&mut env, 0, |_env| {
         let config = Config::from_apikey_env()?;
-        Ok(Box::into_raw(Box::new(config)) as jlong)
+        Ok(crate::handles::insert(config))
     })
 }
 
@@ -46,9 +46,9 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newConfigFromOauth(
     oauth: jlong,
 ) -> jlong {
     jni_result(&mut env, 0, |_env| {
-        let oauth = &*(oauth as *const longbridge::oauth::OAuth);
-        let config = Config::from_oauth(oauth.clone());
-        Ok(Box::into_raw(Box::new(config)) as jlong)
+        let oauth = crate::handles::get::<longbridge::oauth::OAuth>(oauth)?;
+        let config = Config::from_oauth((*oauth).clone());
+        Ok(crate::handles::insert(config))
     })
 }
 
@@ -64,7 +64,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_configSetHttpUrl(
 ) -> jlong {
     jni_result(&mut env, config, |env| {
         let url = String::from_jvalue(env, http_url.into())?;
-        (*(config as *mut Config)).set_http_url(url);
+        crate::handles::update(config, |config: &mut Config| config.set_http_url(url))?;
         Ok(config)
     })
 }
@@ -78,7 +78,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_configSetQuoteWsUrl(
 ) -> jlong {
     jni_result(&mut env, config, |env| {
         let url = String::from_jvalue(env, quote_ws_url.into())?;
-        (*(config as *mut Config)).set_quote_ws_url(url);
+        crate::handles::update(config, |config: &mut Config| config.set_quote_ws_url(url))?;
         Ok(config)
     })
 }
@@ -92,7 +92,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_configSetTradeWsUrl(
 ) -> jlong {
     jni_result(&mut env, config, |env| {
         let url = String::from_jvalue(env, trade_ws_url.into())?;
-        (*(config as *mut Config)).set_trade_ws_url(url);
+        crate::handles::update(config, |config: &mut Config| config.set_trade_ws_url(url))?;
         Ok(config)
     })
 }
@@ -106,7 +106,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_configSetLanguage(
 ) -> jlong {
     jni_result(&mut env, config, |env| {
         let lang = Language::from_jvalue(env, language.into())?;
-        (*(config as *mut Config)).set_language(lang);
+        crate::handles::update(config, |config: &mut Config| config.set_language(lang))?;
         Ok(config)
     })
 }
@@ -118,7 +118,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_configSetEnableOvern
     config: jlong,
 ) -> jlong {
     jni_result(&mut env, config, |_env| {
-        (*(config as *mut Config)).set_enable_overnight();
+        crate::handles::update(config, Config::set_enable_overnight)?;
         Ok(config)
     })
 }
@@ -132,7 +132,9 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_configSetPushCandles
 ) -> jlong {
     jni_result(&mut env, config, |env| {
         let mode = PushCandlestickMode::from_jvalue(env, mode.into())?;
-        (*(config as *mut Config)).set_push_candlestick_mode(mode);
+        crate::handles::update(config, |config: &mut Config| {
+            config.set_push_candlestick_mode(mode)
+        })?;
         Ok(config)
     })
 }
@@ -146,7 +148,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_configSetEnablePrint
 ) -> jlong {
     jni_result(&mut env, config, |_env| {
         if enable == 0 {
-            (*(config as *mut Config)).set_dont_print_quote_packages();
+            crate::handles::update(config, Config::set_dont_print_quote_packages)?;
         }
         Ok(config)
     })
@@ -161,7 +163,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_configSetLogPath(
 ) -> jlong {
     jni_result(&mut env, config, |env| {
         let path = String::from_jvalue(env, log_path.into())?;
-        (*(config as *mut Config)).set_log_path(path);
+        crate::handles::update(config, |config: &mut Config| config.set_log_path(path))?;
         Ok(config)
     })
 }
@@ -173,7 +175,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_configSetEnablePaper
     config: jlong,
 ) -> jlong {
     jni_result(&mut env, config, |_env| {
-        (*(config as *mut Config)).set_enable_papertrading();
+        crate::handles::update(config, Config::set_enable_papertrading)?;
         Ok(config)
     })
 }
@@ -190,7 +192,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_configRefreshAccessT
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let config = &*(config as *const Config);
+        let config = crate::handles::get::<Config>(config)?;
         let expired_at: Option<OffsetDateTime> = FromJValue::from_jvalue(env, expired_at.into())?;
         async_util::execute(env, callback, async move {
             let token = config.refresh_access_token(expired_at).await?;
@@ -208,5 +210,5 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeConfig(
     _class: JClass,
     config: jlong,
 ) {
-    let _ = Box::from_raw(config as *mut Config);
+    crate::handles::remove(config);
 }

--- a/java/src/content_context.rs
+++ b/java/src/content_context.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use jni::{
     JNIEnv,
     objects::{JClass, JObject},
@@ -26,9 +24,9 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newContentContext(
     config: i64,
 ) -> i64 {
     jni_result(&mut env, 0i64, |_env| {
-        let config = Arc::new((*(config as *const Config)).clone());
+        let config = crate::handles::get::<Config>(config)?;
         let ctx = ContentContext::new(config);
-        Ok(Box::into_raw(Box::new(ContextObj { ctx })) as i64)
+        Ok(crate::handles::insert(ContextObj { ctx }))
     })
 }
 
@@ -38,7 +36,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeContentContext(
     _class: JClass,
     ctx: i64,
 ) {
-    let _ = Box::from_raw(ctx as *mut ContextObj);
+    crate::handles::remove(ctx);
 }
 
 #[unsafe(no_mangle)]
@@ -50,7 +48,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_contentContextMyTopi
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let page: Option<JavaInteger> = get_field(env, &opts, "page")?;
         let size: Option<JavaInteger> = get_field(env, &opts, "size")?;
         let topic_type: Option<String> = get_field(env, &opts, "topicType")?;
@@ -79,7 +77,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_contentContextCreate
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let title: String = get_field(env, &opts, "title")?;
         let body: String = get_field(env, &opts, "body")?;
         let topic_type: Option<String> = get_field(env, &opts, "topicType")?;
@@ -110,7 +108,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_contentContextTopics
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             Ok(ObjectArray(context.ctx.topics(symbol).await?))
@@ -128,7 +126,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_contentContextNews(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             Ok(ObjectArray(context.ctx.news(symbol).await?))

--- a/java/src/dca_context.rs
+++ b/java/src/dca_context.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use jni::{
     JNIEnv,
     objects::{JClass, JObject},
@@ -23,9 +21,9 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newDcaContext(
     config: i64,
 ) -> i64 {
     jni_result(&mut env, 0i64, |_env| {
-        Ok(Box::into_raw(Box::new(ContextObj {
-            ctx: DCAContext::new(Arc::new((*(config as *const Config)).clone())),
-        })) as i64)
+        Ok(crate::handles::insert(ContextObj {
+            ctx: DCAContext::new(crate::handles::get::<Config>(config)?),
+        }))
     })
 }
 #[unsafe(no_mangle)]
@@ -34,7 +32,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeDcaContext(
     _class: JClass,
     ctx: i64,
 ) {
-    let _ = Box::from_raw(ctx as *mut ContextObj);
+    crate::handles::remove(ctx);
 }
 
 #[unsafe(no_mangle)]
@@ -46,7 +44,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_dcaContextList(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         let status: Option<DCAStatus> = if opts.is_null() {
             None
         } else {
@@ -73,7 +71,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_dcaContextStats(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         let sym: Option<String> = if symbol.is_null() {
             None
         } else {
@@ -93,7 +91,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_dcaContextCheckSuppo
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         let syms: ObjectArray<String> = FromJValue::from_jvalue(env, symbols.into())?;
         async_util::execute(env, callback, async move {
             Ok(ctx.ctx.check_support(syms.0).await?)
@@ -111,7 +109,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_dcaContextHistory(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         let plan_id: String = get_field(env, &opts, "planId")?;
         let page: Option<JavaInteger> = get_field(env, &opts, "page")?;
         let limit: Option<JavaInteger> = get_field(env, &opts, "limit")?;
@@ -138,7 +136,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_dcaContextPause(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         let id: String = FromJValue::from_jvalue(env, plan_id.into())?;
         async_util::execute(env, callback, async move { Ok(ctx.ctx.pause(id).await?) })?;
         Ok(())
@@ -154,7 +152,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_dcaContextResume(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         let id: String = FromJValue::from_jvalue(env, plan_id.into())?;
         async_util::execute(env, callback, async move { Ok(ctx.ctx.resume(id).await?) })?;
         Ok(())
@@ -170,7 +168,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_dcaContextStop(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         let id: String = FromJValue::from_jvalue(env, plan_id.into())?;
         async_util::execute(env, callback, async move { Ok(ctx.ctx.stop(id).await?) })?;
         Ok(())
@@ -186,7 +184,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_dcaContextCalcDate(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = get_field(env, &opts, "symbol")?;
         let frequency: Option<DCAFrequency> = get_field(env, &opts, "frequency")?;
         let frequency = frequency.unwrap_or(DCAFrequency::Monthly);
@@ -212,7 +210,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_dcaContextSetReminde
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         let h: String = FromJValue::from_jvalue(env, hours.into())?;
         async_util::execute(
             env,
@@ -232,7 +230,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_dcaContextCreate(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = get_field(env, &opts, "symbol")?;
         let amount: String = get_field(env, &opts, "amount")?;
         let freq_v: Option<DCAFrequency> = get_field(env, &opts, "frequency")?;
@@ -268,7 +266,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_dcaContextUpdate(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         let plan_id: String = get_field(env, &opts, "planId")?;
         let amount: Option<String> = get_field(env, &opts, "amount")?;
         let frequency: Option<DCAFrequency> = get_field(env, &opts, "frequency")?;

--- a/java/src/error.rs
+++ b/java/src/error.rs
@@ -19,6 +19,8 @@ pub(crate) enum JniError {
     OpenApi(#[from] Box<longbridge::Error>),
     #[error("{0}")]
     Other(String),
+    #[error("invalid or closed native handle: {0}")]
+    InvalidHandle(i64),
 }
 
 impl From<longbridge::Error> for JniError {
@@ -86,6 +88,10 @@ impl JniError {
             JniError::Jni(err) => Self::into_runtime_error_object(env, err),
             JniError::OpenApi(err) => Self::into_openapi_error_object(env, *err),
             JniError::Other(err) => Self::into_runtime_error_object(env, err),
+            JniError::InvalidHandle(handle) => Self::into_runtime_error_object(
+                env,
+                format!("invalid or closed native handle: {handle}"),
+            ),
         }
         .expect("to error object")
     }
@@ -95,6 +101,9 @@ impl JniError {
             JniError::Jni(err) => Self::throw_runtime_error(env, err),
             JniError::OpenApi(err) => Self::throw_openapi_error(env, *err),
             JniError::Other(err) => Self::throw_runtime_error(env, err),
+            JniError::InvalidHandle(handle) => {
+                Self::throw_runtime_error(env, format!("invalid or closed native handle: {handle}"))
+            }
         };
         if let Err(err) = res {
             env.fatal_error(err.to_string());

--- a/java/src/fundamental_context.rs
+++ b/java/src/fundamental_context.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use jni::{
     JNIEnv,
     objects::{JClass, JObject},
@@ -23,9 +21,9 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newFundamentalContex
     config: i64,
 ) -> i64 {
     jni_result(&mut env, 0i64, |_env| {
-        let config = Arc::new((*(config as *const Config)).clone());
+        let config = crate::handles::get::<Config>(config)?;
         let ctx = FundamentalContext::new(config);
-        Ok(Box::into_raw(Box::new(ContextObj { ctx })) as i64)
+        Ok(crate::handles::insert(ContextObj { ctx }))
     })
 }
 
@@ -35,7 +33,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeFundamentalConte
     _class: JClass,
     ctx: i64,
 ) {
-    let _ = Box::from_raw(ctx as *mut ContextObj);
+    crate::handles::remove(ctx);
 }
 
 // ── financial_report ─────────────────────────────────────────────
@@ -49,7 +47,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_fundamentalContextFi
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = get_field(env, &opts, "symbol")?;
         let kind: Option<FinancialReportKind> = get_field(env, &opts, "kind")?;
         let kind = kind.unwrap_or(FinancialReportKind::All);
@@ -75,7 +73,7 @@ macro_rules! symbol_method {
             callback: JObject,
         ) {
             jni_result(&mut env, (), |env| {
-                let context = &*(context as *const ContextObj);
+                let context = crate::handles::get::<ContextObj>(context)?;
                 let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
                 async_util::execute(env, callback, async move {
                     let resp = context.ctx.$method(symbol).await?;
@@ -164,7 +162,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_fundamentalContextGe
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             let resp = context.ctx.buyback(symbol).await?;
@@ -183,7 +181,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_fundamentalContextGe
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             let resp = context.ctx.ratings(symbol).await?;
@@ -202,7 +200,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_fundamentalContextSh
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             let resp = context.ctx.shareholder_top(symbol).await?;
@@ -222,7 +220,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_fundamentalContextSh
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             let resp = context.ctx.shareholder_detail(symbol, object_id).await?;
@@ -243,7 +241,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_fundamentalContextVa
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         let currency: String = FromJValue::from_jvalue(env, currency.into())?;
         let comparison_syms: Option<Vec<String>> = if comparison_symbols.is_null() {
@@ -275,7 +273,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_fundamentalContextMa
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let country: Option<String> = FromJValue::from_jvalue(env, country.into())?;
         let country = country.and_then(|s| {
             use longbridge::fundamental::MacroeconomicCountry::*;
@@ -315,7 +313,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_fundamentalContextMa
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let indicator_code: String = FromJValue::from_jvalue(env, indicator_code.into())?;
         let start_date: Option<String> = FromJValue::from_jvalue(env, start_time.into())?;
         let end_date: Option<String> = FromJValue::from_jvalue(env, end_time.into())?;
@@ -346,7 +344,7 @@ macro_rules! us_counter_id_method {
             callback: JObject,
         ) {
             jni_result(&mut env, (), |env| {
-                let context = &*(context as *const ContextObj);
+                let context = crate::handles::get::<ContextObj>(context)?;
                 let counter_id: String = FromJValue::from_jvalue(env, counter_id.into())?;
                 async_util::execute(env, callback, async move {
                     let resp = context.ctx.$method(counter_id).await?;
@@ -370,7 +368,7 @@ macro_rules! us_counter_id_report_method {
             callback: JObject,
         ) {
             jni_result(&mut env, (), |env| {
-                let context = &*(context as *const ContextObj);
+                let context = crate::handles::get::<ContextObj>(context)?;
                 let counter_id: String = FromJValue::from_jvalue(env, counter_id.into())?;
                 let report: String = FromJValue::from_jvalue(env, report.into())?;
                 async_util::execute(env, callback, async move {
@@ -423,7 +421,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_fundamentalContextUs
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let counter_id: String = FromJValue::from_jvalue(env, counter_id.into())?;
         let kind: String = FromJValue::from_jvalue(env, kind.into())?;
         let report: String = FromJValue::from_jvalue(env, report.into())?;
@@ -448,7 +446,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_fundamentalContextUs
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let counter_id: String = FromJValue::from_jvalue(env, counter_id.into())?;
         let size: Option<i32> = FromJValue::from_jvalue(env, size.into())?;
         async_util::execute(env, callback, async move {

--- a/java/src/handles.rs
+++ b/java/src/handles.rs
@@ -1,0 +1,115 @@
+use std::{
+    any::Any,
+    collections::HashMap,
+    sync::{
+        Arc, LazyLock,
+        atomic::{AtomicI64, Ordering},
+    },
+};
+
+use parking_lot::RwLock;
+
+use crate::error::JniError;
+
+type ErasedHandle = Arc<dyn Any + Send + Sync>;
+
+static NEXT_HANDLE: AtomicI64 = AtomicI64::new(1);
+static HANDLES: LazyLock<RwLock<HashMap<i64, ErasedHandle>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+pub(crate) fn insert<T>(value: T) -> i64
+where
+    T: Any + Send + Sync,
+{
+    let handle = NEXT_HANDLE.fetch_add(1, Ordering::Relaxed);
+    HANDLES.write().insert(handle, Arc::new(value));
+    handle
+}
+
+pub(crate) fn get<T>(handle: i64) -> Result<Arc<T>, JniError>
+where
+    T: Any + Send + Sync,
+{
+    let value = HANDLES
+        .read()
+        .get(&handle)
+        .cloned()
+        .ok_or_else(|| JniError::InvalidHandle(handle))?;
+
+    value
+        .downcast::<T>()
+        .map_err(|_| JniError::InvalidHandle(handle))
+}
+
+pub(crate) fn remove(handle: i64) {
+    HANDLES.write().remove(&handle);
+}
+
+pub(crate) fn update<T>(handle: i64, update: impl FnOnce(&mut T)) -> Result<(), JniError>
+where
+    T: Any + Clone + Send + Sync,
+{
+    let mut handles = HANDLES.write();
+    let current = handles
+        .get(&handle)
+        .ok_or_else(|| JniError::InvalidHandle(handle))?;
+    let mut value = current
+        .downcast_ref::<T>()
+        .cloned()
+        .ok_or_else(|| JniError::InvalidHandle(handle))?;
+    update(&mut value);
+    handles.insert(handle, Arc::new(value));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Barrier;
+
+    use super::*;
+
+    #[test]
+    fn removing_a_handle_is_idempotent() {
+        let handle = insert(String::from("value"));
+
+        remove(handle);
+        remove(handle);
+
+        assert!(matches!(get::<String>(handle), Err(JniError::InvalidHandle(id)) if id == handle));
+    }
+
+    #[test]
+    fn an_acquired_value_outlives_its_handle() {
+        let handle = insert(String::from("value"));
+        let value = get::<String>(handle).unwrap();
+
+        remove(handle);
+
+        assert_eq!(&*value, "value");
+        assert!(get::<String>(handle).is_err());
+    }
+
+    #[test]
+    fn an_acquired_value_survives_concurrent_removal() {
+        let handle = insert(String::from("value"));
+        let acquired = Arc::new(Barrier::new(2));
+        let removed = Arc::new(Barrier::new(2));
+
+        std::thread::scope(|scope| {
+            let worker_acquired = acquired.clone();
+            let worker_removed = removed.clone();
+            scope.spawn(move || {
+                let value = get::<String>(handle).unwrap();
+                worker_acquired.wait();
+                worker_removed.wait();
+                assert_eq!(&*value, "value");
+            });
+
+            acquired.wait();
+            remove(handle);
+            removed.wait();
+        });
+
+        assert!(get::<String>(handle).is_err());
+    }
+}

--- a/java/src/http_client.rs
+++ b/java/src/http_client.rs
@@ -32,7 +32,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newHttpClientFromApi
         if !http_url.is_null() {
             config = config.http_url(String::from_jvalue(env, http_url.into())?);
         }
-        Ok(Box::into_raw(Box::new(HttpClient::new(config))) as jlong)
+        Ok(crate::handles::insert(HttpClient::new(config)))
     })
 }
 
@@ -46,7 +46,7 @@ pub extern "system" fn Java_com_longbridge_SdkNative_newHttpClientFromApikeyEnv(
             longbridge::httpclient::HttpClientConfig::from_apikey_env()
                 .map_err(longbridge::Error::HttpClient)?,
         );
-        Ok(Box::into_raw(Box::new(config)) as jlong)
+        Ok(crate::handles::insert(config))
     })
 }
 
@@ -58,12 +58,12 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newHttpClientFromOau
     http_url: JString,
 ) -> jlong {
     jni_result(&mut env, 0, |env| {
-        let oauth = &*(oauth as *const longbridge::oauth::OAuth);
-        let mut config = HttpClientConfig::from_oauth(oauth.clone());
+        let oauth = crate::handles::get::<longbridge::oauth::OAuth>(oauth)?;
+        let mut config = HttpClientConfig::from_oauth((*oauth).clone());
         if !http_url.is_null() {
             config = config.http_url(String::from_jvalue(env, http_url.into())?);
         }
-        Ok(Box::into_raw(Box::new(HttpClient::new(config))) as jlong)
+        Ok(crate::handles::insert(HttpClient::new(config)))
     })
 }
 
@@ -73,7 +73,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeHttpClient(
     _class: JClass,
     http_client: i64,
 ) {
-    let _ = Box::from_raw(http_client as *mut HttpClient);
+    crate::handles::remove(http_client);
 }
 
 #[unsafe(no_mangle)]
@@ -93,7 +93,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_httpClientRequest(
     }
 
     jni_result(&mut env, (), |env| {
-        let http_client = &*(http_client as *const HttpClient);
+        let http_client = crate::handles::get::<HttpClient>(http_client)?;
         let request = String::from_jvalue(env, request.into())?;
         let request: Request =
             serde_json::from_str(&request).map_err(|err| JniError::Other(err.to_string()))?;

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -11,6 +11,7 @@ mod content_context;
 mod dca_context;
 mod error;
 mod fundamental_context;
+mod handles;
 mod http_client;
 mod init;
 mod market_context;

--- a/java/src/market_context.rs
+++ b/java/src/market_context.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use jni::{
     JNIEnv,
     objects::{JClass, JObject},
@@ -23,9 +21,9 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newMarketContext(
     config: i64,
 ) -> i64 {
     jni_result(&mut env, 0i64, |_env| {
-        let config = Arc::new((*(config as *const Config)).clone());
+        let config = crate::handles::get::<Config>(config)?;
         let ctx = MarketContext::new(config);
-        Ok(Box::into_raw(Box::new(ContextObj { ctx })) as i64)
+        Ok(crate::handles::insert(ContextObj { ctx }))
     })
 }
 
@@ -35,7 +33,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeMarketContext(
     _class: JClass,
     ctx: i64,
 ) {
-    let _ = Box::from_raw(ctx as *mut ContextObj);
+    crate::handles::remove(ctx);
 }
 
 #[unsafe(no_mangle)]
@@ -46,7 +44,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_marketContextMarketS
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move {
             let resp = context.ctx.market_status().await?;
             Ok(resp)
@@ -64,7 +62,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_marketContextBrokerH
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = get_field(env, &opts, "symbol")?;
         let period: Option<BrokerHoldingPeriod> = get_field(env, &opts, "period")?;
         let period = period.unwrap_or(BrokerHoldingPeriod::Rct1);
@@ -85,7 +83,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_marketContextBrokerH
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = get_field(env, &opts, "symbol")?;
         let broker_id: String = get_field(env, &opts, "brokerId")?;
         async_util::execute(env, callback, async move {
@@ -105,7 +103,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_marketContextAhPremi
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = get_field(env, &opts, "symbol")?;
         let period: Option<AhPremiumPeriod> = get_field(env, &opts, "period")?;
         let period = period.unwrap_or(AhPremiumPeriod::Day);
@@ -130,7 +128,7 @@ macro_rules! symbol_method {
             callback: JObject,
         ) {
             jni_result(&mut env, (), |env| {
-                let context = &*(context as *const ContextObj);
+                let context = crate::handles::get::<ContextObj>(context)?;
                 let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
                 async_util::execute(env, callback, async move {
                     let resp = context.ctx.$method(symbol).await?;
@@ -153,7 +151,7 @@ macro_rules! market_method {
             callback: JObject,
         ) {
             jni_result(&mut env, (), |env| {
-                let context = &*(context as *const ContextObj);
+                let context = crate::handles::get::<ContextObj>(context)?;
                 let market: String = FromJValue::from_jvalue(env, market.into())?;
                 async_util::execute(env, callback, async move {
                     let resp = context.ctx.$method(market).await?;
@@ -192,7 +190,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_marketContextTopMove
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let markets_raw: ObjectArray<String> = get_field(env, &opts, "markets")?;
         let markets: Vec<String> = markets_raw.0;
         let sort_opt: Option<JavaInteger> = get_field(env, &opts, "sort")?;
@@ -216,7 +214,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_marketContextRankCat
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move {
             let resp = context.ctx.rank_categories().await?;
             Ok(resp)
@@ -235,7 +233,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_marketContextRankLis
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let key: String = FromJValue::from_jvalue(env, key.into())?;
         async_util::execute(env, callback, async move {
             let resp = context.ctx.rank_list(key, need_article).await?;

--- a/java/src/oauth.rs
+++ b/java/src/oauth.rs
@@ -3,7 +3,7 @@ use jni::{
     objects::{JClass, JObject, JString},
     sys::{jint, jlong},
 };
-use longbridge::oauth::{OAuth, OAuthBuilder};
+use longbridge::oauth::OAuthBuilder;
 
 use crate::{async_util, error::jni_result, types::JavaLong};
 
@@ -14,8 +14,7 @@ use crate::{async_util, error::jni_result, types::JavaLong};
 ///
 /// `callback_port == 0` means "use the default (60355)".
 /// `openUrlCallback` must be a `java.util.function.Consumer<String>`.
-/// On success the async `callback` receives a heap-allocated `*mut OAuth`
-/// cast to `jlong`; the caller is responsible for calling `freeOAuth`.
+/// On success the async `callback` receives an opaque OAuth handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "system" fn Java_com_longbridge_SdkNative_oauthBuild(
     mut env: JNIEnv,
@@ -51,18 +50,18 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_oauthBuild(
                 })
                 .await
                 .map_err(|e| crate::error::JniError::Other(e.to_string()))?;
-            Ok(JavaLong::from(Box::into_raw(Box::new(oauth)) as jlong))
+            Ok(JavaLong::from(crate::handles::insert(oauth)))
         })?;
         Ok(())
     })
 }
 
-/// Free an OAuth pointer.
+/// Release an OAuth handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeOAuth(
     _env: JNIEnv,
     _class: JClass,
     oauth: jlong,
 ) {
-    drop(Box::from_raw(oauth as *mut OAuth));
+    crate::handles::remove(oauth);
 }

--- a/java/src/portfolio_context.rs
+++ b/java/src/portfolio_context.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use jni::{
     JNIEnv,
     objects::{JClass, JObject},
@@ -23,9 +21,9 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newPortfolioContext(
     config: i64,
 ) -> i64 {
     jni_result(&mut env, 0i64, |_env| {
-        let config = Arc::new((*(config as *const Config)).clone());
+        let config = crate::handles::get::<Config>(config)?;
         let ctx = PortfolioContext::new(config);
-        Ok(Box::into_raw(Box::new(ContextObj { ctx })) as i64)
+        Ok(crate::handles::insert(ContextObj { ctx }))
     })
 }
 
@@ -35,7 +33,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freePortfolioContext
     _class: JClass,
     ctx: i64,
 ) {
-    let _ = Box::from_raw(ctx as *mut ContextObj);
+    crate::handles::remove(ctx);
 }
 
 #[unsafe(no_mangle)]
@@ -46,7 +44,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_portfolioContextExch
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move {
             Ok(context.ctx.exchange_rate().await?)
         })?;
@@ -63,7 +61,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_portfolioContextProf
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let start: Option<String> = if opts.is_null() {
             None
         } else {
@@ -90,7 +88,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_portfolioContextProf
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = get_field(env, &opts, "symbol")?;
         let start: Option<String> = get_field(env, &opts, "start")?;
         let end: Option<String> = get_field(env, &opts, "end")?;
@@ -113,7 +111,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_portfolioContextProf
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let market: Option<String> = if opts.is_null() {
             None
         } else {
@@ -157,7 +155,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_portfolioContextProf
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = get_field(env, &opts, "symbol")?;
         let page_v: Option<JavaInteger> = get_field(env, &opts, "page")?;
         let page: u32 = page_v.map(|v| i32::from(v) as u32).unwrap_or(1);

--- a/java/src/quote_context.rs
+++ b/java/src/quote_context.rs
@@ -116,7 +116,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newQuoteContext(
     config: i64,
 ) -> i64 {
     jni_result(&mut env, 0i64, |env| {
-        let config = Arc::new((*(config as *const Config)).clone());
+        let config = crate::handles::get::<Config>(config)?;
         let jvm = env.get_java_vm()?;
 
         let (ctx, mut receiver) = QuoteContext::new(config);
@@ -132,7 +132,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newQuoteContext(
             }
         });
 
-        Ok(Box::into_raw(Box::new(ContextObj { ctx, callbacks })) as i64)
+        Ok(crate::handles::insert(ContextObj { ctx, callbacks }))
     })
 }
 
@@ -142,7 +142,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeQuoteContext(
     _class: JClass,
     ctx: i64,
 ) {
-    let _ = Box::from_raw(ctx as *mut ContextObj);
+    crate::handles::remove(ctx);
 }
 
 #[unsafe(no_mangle)]
@@ -152,9 +152,9 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextGetMembe
     ctx: i64,
     callback: JObject,
 ) {
-    let context = &*(ctx as *const ContextObj);
-    let ctx = context.ctx.clone();
     jni_result(&mut env, (), |env| {
+        let context = crate::handles::get::<ContextObj>(ctx)?;
+        let ctx = context.ctx.clone();
         Ok(async_util::execute::<i64, _>(env, callback, async move {
             ctx.member_id().await.map_err(Into::into)
         })?)
@@ -168,9 +168,9 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextGetQuote
     ctx: i64,
     callback: JObject,
 ) {
-    let context = &*(ctx as *const ContextObj);
-    let ctx = context.ctx.clone();
     jni_result(&mut env, (), |env| {
+        let context = crate::handles::get::<ContextObj>(ctx)?;
+        let ctx = context.ctx.clone();
         Ok(async_util::execute::<String, _>(
             env,
             callback,
@@ -186,9 +186,9 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextGetQuote
     ctx: i64,
     callback: JObject,
 ) {
-    let context = &*(ctx as *const ContextObj);
-    let ctx = context.ctx.clone();
     jni_result(&mut env, (), |env| {
+        let context = crate::handles::get::<ContextObj>(ctx)?;
+        let ctx = context.ctx.clone();
         Ok(async_util::execute::<ObjectArray<_>, _>(
             env,
             callback,
@@ -209,8 +209,8 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextSetOnQuo
     ctx: i64,
     handler: JObject,
 ) {
-    let context = &*(ctx as *const ContextObj);
     jni_result(&mut env, (), |env| {
+        let context = crate::handles::get::<ContextObj>(ctx)?;
         if !handler.is_null() {
             context.callbacks.lock().quote = Some(env.new_global_ref(handler)?);
         } else {
@@ -227,8 +227,8 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextSetOnDep
     ctx: i64,
     handler: JObject,
 ) {
-    let context = &*(ctx as *const ContextObj);
     jni_result(&mut env, (), |env| {
+        let context = crate::handles::get::<ContextObj>(ctx)?;
         if !handler.is_null() {
             context.callbacks.lock().depth = Some(env.new_global_ref(handler)?);
         } else {
@@ -245,8 +245,8 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextSetOnBro
     ctx: i64,
     handler: JObject,
 ) {
-    let context = &*(ctx as *const ContextObj);
     jni_result(&mut env, (), |env| {
+        let context = crate::handles::get::<ContextObj>(ctx)?;
         if !handler.is_null() {
             context.callbacks.lock().brokers = Some(env.new_global_ref(handler)?);
         } else {
@@ -263,8 +263,8 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextSetOnTra
     ctx: i64,
     handler: JObject,
 ) {
-    let context = &*(ctx as *const ContextObj);
     jni_result(&mut env, (), |env| {
+        let context = crate::handles::get::<ContextObj>(ctx)?;
         if !handler.is_null() {
             context.callbacks.lock().trades = Some(env.new_global_ref(handler)?);
         } else {
@@ -281,8 +281,8 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextSetOnCan
     ctx: i64,
     handler: JObject,
 ) {
-    let context = &*(ctx as *const ContextObj);
     jni_result(&mut env, (), |env| {
+        let context = crate::handles::get::<ContextObj>(ctx)?;
         if !handler.is_null() {
             context.callbacks.lock().candlestick = Some(env.new_global_ref(handler)?);
         } else {
@@ -302,7 +302,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextSubscrib
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbols: ObjectArray<String> =
             FromJValue::from_jvalue(env, JObject::from_raw(symbols).into())?;
         let sub_flags = SubFlags::from_bits(flags as u8).unwrap_or(SubFlags::empty());
@@ -323,7 +323,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextUnsubscr
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbols: ObjectArray<String> =
             FromJValue::from_jvalue(env, JObject::from_raw(symbols).into())?;
         let sub_flags = SubFlags::from_bits(flags as u8).unwrap_or(SubFlags::empty());
@@ -345,7 +345,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextSubscrib
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         let period: Period = FromJValue::from_jvalue(env, period.into())?;
         let trade_sessions: TradeSessions = FromJValue::from_jvalue(env, trade_sessions.into())?;
@@ -371,7 +371,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextUnsubscr
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         let period: Period = FromJValue::from_jvalue(env, period.into())?;
         async_util::execute(env, callback, async move {
@@ -389,7 +389,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextSubscrip
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move {
             let list = context.ctx.subscriptions().await?;
             Ok(ObjectArray(list))
@@ -407,7 +407,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextStaticIn
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbols: ObjectArray<String> =
             FromJValue::from_jvalue(env, JObject::from_raw(symbols).into())?;
         async_util::execute(env, callback, async move {
@@ -427,7 +427,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextQuote(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbols: ObjectArray<String> =
             FromJValue::from_jvalue(env, JObject::from_raw(symbols).into())?;
         async_util::execute(env, callback, async move {
@@ -447,7 +447,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextOptionQu
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbols: ObjectArray<String> =
             FromJValue::from_jvalue(env, JObject::from_raw(symbols).into())?;
         async_util::execute(env, callback, async move {
@@ -467,7 +467,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextWarrantQ
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbols: ObjectArray<String> =
             FromJValue::from_jvalue(env, JObject::from_raw(symbols).into())?;
         async_util::execute(env, callback, async move {
@@ -487,7 +487,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextDepth(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             Ok(context.ctx.depth(symbol).await?)
@@ -505,7 +505,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextBrokers(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             Ok(context.ctx.brokers(symbol).await?)
@@ -522,7 +522,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextParticip
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move {
             Ok(ObjectArray(context.ctx.participants().await?))
         })?;
@@ -540,7 +540,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextTrades(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             Ok(ObjectArray(
@@ -561,7 +561,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextIntraday
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         let trade_sessions: TradeSessions = FromJValue::from_jvalue(env, trade_sessions.into())?;
         async_util::execute(env, callback, async move {
@@ -586,7 +586,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextCandlest
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         let period: Period = FromJValue::from_jvalue(env, period.into())?;
         let adjust_type: AdjustType = FromJValue::from_jvalue(env, adjust_type.into())?;
@@ -624,7 +624,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextHistoryC
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         let period: Period = FromJValue::from_jvalue(env, period.into())?;
         let adjust_type: AdjustType = FromJValue::from_jvalue(env, adjust_type.into())?;
@@ -664,7 +664,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextHistoryC
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         let period: Period = FromJValue::from_jvalue(env, period.into())?;
         let adjust_type: AdjustType = FromJValue::from_jvalue(env, adjust_type.into())?;
@@ -699,7 +699,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextOptionCh
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             Ok(ObjectArray(
@@ -720,7 +720,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextOptionCh
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         let expiry_date: Date = FromJValue::from_jvalue(env, expiry_date.into())?;
         async_util::execute(env, callback, async move {
@@ -743,7 +743,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextWarrantI
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move {
             Ok(ObjectArray(context.ctx.warrant_issuers().await?))
         })?;
@@ -760,7 +760,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextWarrantL
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = get_field(env, &opts, "symbol")?;
         let sort_by: WarrantSortBy = get_field(env, &opts, "sortBy")?;
         let sort_type: SortOrderType = get_field(env, &opts, "sortType")?;
@@ -801,7 +801,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextTradingS
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move {
             Ok(ObjectArray(context.ctx.trading_session().await?))
         })?;
@@ -820,7 +820,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextTradingD
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let market: Market = FromJValue::from_jvalue(env, market.into())?;
         let begin: Date = FromJValue::from_jvalue(env, begin.into())?;
         let end: Date = FromJValue::from_jvalue(env, end.into())?;
@@ -840,7 +840,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextCapitalF
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             Ok(ObjectArray(context.ctx.capital_flow(symbol).await?))
@@ -858,7 +858,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextCapitalD
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             Ok(context.ctx.capital_distribution(symbol).await?)
@@ -877,7 +877,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextCalcInde
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbols: ObjectArray<String> =
             FromJValue::from_jvalue(env, JObject::from_raw(symbols).into())?;
         let indexes: ObjectArray<CalcIndex> =
@@ -905,7 +905,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextWatchlis
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move {
             Ok(ObjectArray(context.ctx.watchlist().await?))
         })?;
@@ -922,7 +922,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextCreateWa
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let name: String = get_field(env, &req, "name")?;
         let securities: Option<ObjectArray<String>> = get_field(env, &req, "securities")?;
         async_util::execute(env, callback, async move {
@@ -948,7 +948,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextDeleteWa
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let id: i64 = get_field(env, &req, "id")?;
         let purge: bool = get_field(env, &req, "purge")?;
         async_util::execute(env, callback, async move {
@@ -967,7 +967,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextUpdateWa
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let id: i64 = get_field(env, &req, "id")?;
         let name: Option<String> = get_field(env, &req, "name")?;
         let securities: Option<ObjectArray<String>> = get_field(env, &req, "securities")?;
@@ -997,7 +997,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextUpdatePi
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let mode: PinnedMode = get_field(env, &req, "mode")?;
         let symbols: ObjectArray<String> = get_field(env, &req, "symbols")?;
         async_util::execute(env, callback, async move {
@@ -1017,7 +1017,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextRealtime
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbols: ObjectArray<String> = FromJValue::from_jvalue(env, symbols.into())?;
         async_util::execute(env, callback, async move {
             Ok(ObjectArray(context.ctx.realtime_quote(symbols.0).await?))
@@ -1035,7 +1035,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextRealtime
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             Ok(context.ctx.realtime_depth(symbol).await?)
@@ -1053,7 +1053,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextRealtime
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             Ok(context.ctx.realtime_brokers(symbol).await?)
@@ -1072,7 +1072,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextRealtime
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             Ok(ObjectArray(
@@ -1097,7 +1097,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextRealtime
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         let period: Period = FromJValue::from_jvalue(env, period.into())?;
         async_util::execute(env, callback, async move {
@@ -1121,7 +1121,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextFilings(
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             Ok(ObjectArray(context.ctx.filings(symbol).await?))
@@ -1140,7 +1140,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextSecurity
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let market: Market = FromJValue::from_jvalue(env, market.into())?;
         let category: Option<SecurityListCategory> = FromJValue::from_jvalue(env, category.into())?;
         async_util::execute(env, callback, async move {
@@ -1161,7 +1161,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextMarketTe
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let market: Market = FromJValue::from_jvalue(env, market.into())?;
         async_util::execute(env, callback, async move {
             Ok(context.ctx.market_temperature(market).await?)
@@ -1181,7 +1181,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextHistoryM
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let market: Market = FromJValue::from_jvalue(env, market.into())?;
         let start: Date = FromJValue::from_jvalue(env, start.into())?;
         let end: Date = FromJValue::from_jvalue(env, end.into())?;
@@ -1205,7 +1205,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextShortPos
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         let count = count.max(1) as u32;
         async_util::execute(env, callback, async move {
@@ -1226,7 +1226,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextShortTra
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         let count = count.max(1) as u32;
         async_util::execute(env, callback, async move {
@@ -1246,7 +1246,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextOptionVo
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             let resp = context.ctx.option_volume(symbol).await?;
@@ -1266,7 +1266,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextOptionVo
 ) {
     use crate::types::{JavaInteger, JavaLong, get_field};
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = get_field(env, &opts, "symbol")?;
         let timestamp_opt: Option<JavaLong> = get_field(env, &opts, "timestamp")?;
         let timestamp = timestamp_opt.map(i64::from).unwrap_or(0);
@@ -1292,7 +1292,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_quoteContextUsCrypto
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             let resp = context.ctx.us_crypto_overview(symbol).await?;

--- a/java/src/screener_context.rs
+++ b/java/src/screener_context.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use jni::{
     JNIEnv,
     objects::{JClass, JObject, JString},
@@ -18,13 +16,15 @@ struct ContextObj {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newScreenerContext(
-    _env: JNIEnv,
+    mut env: JNIEnv,
     _class: JClass,
     config: i64,
 ) -> i64 {
-    let config = &*(config as *const Config);
-    let ctx = ScreenerContext::new(Arc::new(config.clone()));
-    Box::into_raw(Box::new(ContextObj { ctx })) as i64
+    jni_result(&mut env, 0, |_env| {
+        let config = crate::handles::get::<Config>(config)?;
+        let ctx = ScreenerContext::new(config);
+        Ok(crate::handles::insert(ContextObj { ctx }))
+    })
 }
 
 #[unsafe(no_mangle)]
@@ -33,7 +33,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeScreenerContext(
     _class: JClass,
     context: i64,
 ) {
-    let _ = Box::from_raw(context as *mut ContextObj);
+    crate::handles::remove(context);
 }
 
 #[unsafe(no_mangle)]
@@ -45,7 +45,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_screenerContextRecom
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let market: String = FromJValue::from_jvalue(env, market.into())?;
         async_util::execute(env, callback, async move {
             let resp = context.ctx.screener_recommend_strategies(market).await?;
@@ -64,7 +64,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_screenerContextUserS
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let market: String = FromJValue::from_jvalue(env, market.into())?;
         async_util::execute(env, callback, async move {
             let resp = context.ctx.screener_user_strategies(market).await?;
@@ -83,7 +83,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_screenerContextStrat
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move {
             let resp = context.ctx.screener_strategy(id).await?;
             Ok(resp)
@@ -101,7 +101,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_screenerContextSearc
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let market: String = get_field(env, &opts, "market")?;
         let strategy_id: Option<i64> = get_field(env, &opts, "strategyId")?;
         let page_opt: Option<JavaInteger> = get_field(env, &opts, "page")?;
@@ -127,7 +127,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_screenerContextIndic
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move {
             let resp = context.ctx.screener_indicators().await?;
             Ok(resp)

--- a/java/src/sharelist_context.rs
+++ b/java/src/sharelist_context.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use jni::{
     JNIEnv,
     objects::{JClass, JObject},
@@ -23,9 +21,9 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newSharelistContext(
     config: i64,
 ) -> i64 {
     jni_result(&mut env, 0i64, |_env| {
-        Ok(Box::into_raw(Box::new(ContextObj {
-            ctx: SharelistContext::new(Arc::new((*(config as *const Config)).clone())),
-        })) as i64)
+        Ok(crate::handles::insert(ContextObj {
+            ctx: SharelistContext::new(crate::handles::get::<Config>(config)?),
+        }))
     })
 }
 #[unsafe(no_mangle)]
@@ -34,7 +32,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeSharelistContext
     _class: JClass,
     ctx: i64,
 ) {
-    let _ = Box::from_raw(ctx as *mut ContextObj);
+    crate::handles::remove(ctx);
 }
 
 #[unsafe(no_mangle)]
@@ -46,7 +44,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_sharelistContextList
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move {
             Ok(ctx.ctx.list(count as u32).await?)
         })?;
@@ -62,7 +60,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_sharelistContextDeta
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move { Ok(ctx.ctx.detail(id).await?) })?;
         Ok(())
     })
@@ -76,7 +74,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_sharelistContextPopu
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move {
             Ok(ctx.ctx.popular(count as u32).await?)
         })?;
@@ -92,7 +90,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_sharelistContextCrea
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         let name: String = get_field(env, &opts, "name")?;
         let description: Option<String> = get_field(env, &opts, "description")?;
         async_util::execute(env, callback, async move {
@@ -111,7 +109,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_sharelistContextAddS
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         let syms: ObjectArray<String> = FromJValue::from_jvalue(env, symbols.into())?;
         async_util::execute(env, callback, async move {
             ctx.ctx.add_securities(id, syms.0).await?;
@@ -130,7 +128,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_sharelistContextRemo
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         let syms: ObjectArray<String> = FromJValue::from_jvalue(env, symbols.into())?;
         async_util::execute(env, callback, async move {
             ctx.ctx.remove_securities(id, syms.0).await?;
@@ -149,7 +147,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_sharelistContextSort
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         let syms: ObjectArray<String> = FromJValue::from_jvalue(env, symbols.into())?;
         async_util::execute(env, callback, async move {
             ctx.ctx.sort_securities(id, syms.0).await?;
@@ -168,7 +166,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_sharelistContextDele
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let ctx = &*(context as *const ContextObj);
+        let ctx = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move {
             ctx.ctx.delete(id).await?;
             Ok(())

--- a/java/src/trade_context.rs
+++ b/java/src/trade_context.rs
@@ -63,7 +63,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newTradeContext(
     config: i64,
 ) -> i64 {
     jni_result(&mut env, 0i64, |env| {
-        let config = Arc::new((*(config as *const Config)).clone());
+        let config = crate::handles::get::<Config>(config)?;
         let jvm = env.get_java_vm()?;
 
         let (ctx, mut receiver) = TradeContext::new(config);
@@ -79,7 +79,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_newTradeContext(
             }
         });
 
-        Ok(Box::into_raw(Box::new(ContextObj { ctx, callbacks })) as i64)
+        Ok(crate::handles::insert(ContextObj { ctx, callbacks }))
     })
 }
 
@@ -89,7 +89,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_freeTradeContext(
     _class: JClass,
     ctx: i64,
 ) {
-    let _ = Box::from_raw(ctx as *mut ContextObj);
+    crate::handles::remove(ctx);
 }
 
 #[unsafe(no_mangle)]
@@ -99,8 +99,8 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextSetOnOrd
     ctx: i64,
     handler: JObject,
 ) {
-    let context = &*(ctx as *const ContextObj);
     jni_result(&mut env, (), |env| {
+        let context = crate::handles::get::<ContextObj>(ctx)?;
         if !handler.is_null() {
             context.callbacks.lock().order_changed = Some(env.new_global_ref(handler)?);
         } else {
@@ -119,7 +119,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextSubscrib
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let topics: ObjectArray<TopicType> =
             FromJValue::from_jvalue(env, JObject::from_raw(topics).into())?;
         async_util::execute(env, callback, async move {
@@ -138,7 +138,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextUnsubscr
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let topics: ObjectArray<TopicType> =
             FromJValue::from_jvalue(env, JObject::from_raw(topics).into())?;
         async_util::execute(env, callback, async move {
@@ -157,7 +157,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextHistoryE
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let opts = if !opts.is_null() {
             let mut new_opts = GetHistoryExecutionsOptions::new();
             let symbol: Option<String> = get_field(env, &opts, "symbol")?;
@@ -192,7 +192,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextTodayExe
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let opts = if !opts.is_null() {
             let mut new_opts = GetTodayExecutionsOptions::new();
             let symbol: Option<String> = get_field(env, &opts, "symbol")?;
@@ -224,7 +224,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextTodayExe
 // callback: JObject,
 // ) {
 // jni_result(&mut env, (), |env| {
-// let context = &*(context as *const ContextObj);
+// let context = crate::handles::get::<ContextObj>(context)?;
 // let opts = if !opts.is_null() {
 // let mut new_opts = GetAllExecutionsOptions::new();
 // let symbol: Option<String> = get_field(env, &opts, "symbol")?;
@@ -267,7 +267,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextHistoryO
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let opts = if !opts.is_null() {
             let mut new_opts = GetHistoryOrdersOptions::new();
             let symbol: Option<String> = get_field(env, &opts, "symbol")?;
@@ -312,7 +312,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextTodayOrd
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let opts = if !opts.is_null() {
             let mut new_opts = GetTodayOrdersOptions::new();
             let symbol: Option<String> = get_field(env, &opts, "symbol")?;
@@ -468,7 +468,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextReplaceO
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let order_id: String = get_field(env, &opts, "orderId")?;
         let quantity: Decimal = get_field(env, &opts, "quantity")?;
         let mut new_opts = ReplaceOrderOptions::new(order_id, quantity);
@@ -541,7 +541,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextSubmitOr
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = get_field(env, &opts, "symbol")?;
         let quantity: OrderType = get_field(env, &opts, "orderType")?;
         let side: OrderSide = get_field(env, &opts, "side")?;
@@ -630,7 +630,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextCancelOr
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let order_id: String = FromJValue::from_jvalue(env, order_id.into())?;
         async_util::execute(env, callback, async move {
             Ok(context.ctx.cancel_order(order_id).await?)
@@ -648,7 +648,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextCancelOr
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let order_id: String = FromJValue::from_jvalue(env, order_id.into())?;
         async_util::execute(env, callback, async move {
             Ok(context
@@ -669,7 +669,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextAccountB
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let currency: Option<String> = FromJValue::from_jvalue(env, currency.into())?;
         async_util::execute(env, callback, async move {
             Ok(ObjectArray(
@@ -689,7 +689,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextCashFlow
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let start_at: OffsetDateTime = get_field(env, &opts, "startAt")?;
         let end_at: OffsetDateTime = get_field(env, &opts, "endAt")?;
         let mut new_opts = GetCashFlowOptions::new(start_at, end_at);
@@ -727,7 +727,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextFundPosi
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let opts = if !opts.is_null() {
             let mut new_opts = GetFundPositionsOptions::new();
             let symbols: ObjectArray<String> = get_field(env, opts, "symbols")?;
@@ -752,7 +752,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextStockPos
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let opts = if !opts.is_null() {
             let mut new_opts = GetStockPositionsOptions::new();
             let symbols: ObjectArray<String> = get_field(env, opts, "symbols")?;
@@ -779,7 +779,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextMarginRa
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = FromJValue::from_jvalue(env, symbol.into())?;
         async_util::execute(env, callback, async move {
             Ok(context.ctx.margin_ratio(symbol).await?)
@@ -797,7 +797,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextOrderDet
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let order_id: String = FromJValue::from_jvalue(env, order_id.into())?;
         async_util::execute(env, callback, async move {
             Ok(context.ctx.order_detail(order_id).await?)
@@ -815,7 +815,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextEstimate
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol: String = get_field(env, &opts, "symbol")?;
         let order_type: OrderType = get_field(env, &opts, "orderType")?;
         let side: OrderSide = get_field(env, &opts, "side")?;
@@ -860,7 +860,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextUsQueryO
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let symbol_str: String = FromJValue::from_jvalue(env, symbol.into())?;
         let us_opts = longbridge::trade::GetUSHistoryOrders {
             symbol: if symbol_str.is_empty() {
@@ -896,7 +896,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextUsOrderD
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let order_id: String = FromJValue::from_jvalue(env, order_id.into())?;
         async_util::execute(env, callback, async move {
             let resp = context.ctx.us_order_detail(order_id).await?;
@@ -914,7 +914,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextUsAssetO
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         async_util::execute(env, callback, async move {
             let resp = context.ctx.us_asset_overview().await?;
             Ok(serde_json::to_string(&resp).unwrap_or_default())
@@ -933,7 +933,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextUsRealiz
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let currency: String = FromJValue::from_jvalue(env, currency.into())?;
         let category: Option<String> = FromJValue::from_jvalue(env, category.into()).ok();
         async_util::execute(env, callback, async move {
@@ -959,7 +959,7 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_tradeContextOrderDet
     callback: JObject,
 ) {
     jni_result(&mut env, (), |env| {
-        let context = &*(context as *const ContextObj);
+        let context = crate::handles::get::<ContextObj>(context)?;
         let order_id: String = FromJValue::from_jvalue(env, order_id.into())?;
         async_util::execute(env, callback, async move {
             Ok(context


### PR DESCRIPTION
## Summary

- replace Java SDK JNI raw pointers with a type-safe native handle registry
- keep native objects alive while async operations are in flight and make repeated close calls safe
- return Java runtime errors for invalid or closed handles and add lifecycle regression coverage

## Test Plan

- `cargo clippy --all --all-features`
- `cargo +nightly fmt --all`
- `cargo test -p longbridge-java`
- `mvn test` from `java/javasrc`
- `git diff --check`