### PR TITLE
ci(java): run native library tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,9 @@ jobs:
       - name: Check with clippy
         run: cargo clippy -p longbridge-java --all-features
 
+      - name: Test native library
+        run: cargo test -p longbridge-java --all-features
+
       - name: Compile java sources
         working-directory: java/javasrc
         run: mvn package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **All languages:** add optional `parent_message_id` parameter to the AI Agent `conversation` and `conversation_streamed` methods — pass the `message_id` from a previous response to attach a follow-up message after the specified one, keeping the message stream in order. Only valid together with `chat_uid`; must not be set for a new conversation
 
+### Changed
+
+- **Java SDK:** enable the native library test suite in CI on Linux, Windows, and macOS
+
 ## [4.4.3] - 2026-07-30
 
 ### Fixed


### PR DESCRIPTION
## Summary

- run the Rust-backed Java native library test suite in the existing Java CI job
- execute it across the existing Linux, Windows, and macOS matrix
- document the CI coverage change in the changelog

PR #560 adds three native handle lifecycle regression tests. Against the current `main` branch this command runs an empty test harness; after #560 merges, these CI jobs will execute those tests on all three operating systems.

## Test Plan

- `cargo test -p longbridge-java --all-features`
- workflow YAML parse check
- `git diff --check`