### PR TITLE
feat(agent): capture full Reference content and ChatStartedPayload fields

### DIFF
--- a/c/csrc/include/longbridge.h
+++ b/c/csrc/include/longbridge.h
@@ -1916,9 +1916,21 @@ typedef struct lb_chat_started_payload_t {
    */
   const char *chat_uid;
   /**
+   * Numeric conversation identifier
+   */
+  int64_t chat_id;
+  /**
    * Message ID of this round
    */
   const char *message_id;
+  /**
+   * Error code; empty when absent
+   */
+  const char *error;
+  /**
+   * Error message; empty when absent
+   */
+  const char *error_message;
 } lb_chat_started_payload_t;
 
 /**
@@ -2097,6 +2109,18 @@ typedef struct lb_reference_t {
    */
   int32_t index;
   /**
+   * Original reference index as provided by the source
+   */
+  int32_t original_index;
+  /**
+   * Reference type (wire field `type`)
+   */
+  const char *ref_type;
+  /**
+   * Reference identifier
+   */
+  const char *id;
+  /**
    * Reference title
    */
   const char *title;
@@ -2104,6 +2128,10 @@ typedef struct lb_reference_t {
    * Reference URL
    */
   const char *url;
+  /**
+   * Full nested reference payload, as a JSON string; empty when absent
+   */
+  const char *content_json;
 } lb_reference_t;
 
 /**

--- a/c/src/agent_context/types.rs
+++ b/c/src/agent_context/types.rs
@@ -253,26 +253,53 @@ pub struct CGetAgentsOptions {
 pub struct CReference {
     /// Reference index
     pub index: i32,
+    /// Original reference index as provided by the source
+    pub original_index: i32,
+    /// Reference type (wire field `type`)
+    pub ref_type: *const c_char,
+    /// Reference identifier
+    pub id: *const c_char,
     /// Reference title
     pub title: *const c_char,
     /// Reference URL
     pub url: *const c_char,
+    /// Full nested reference payload, as a JSON string; empty when absent
+    pub content_json: *const c_char,
 }
 
 #[derive(Debug)]
 pub(crate) struct CReferenceOwned {
     index: i32,
+    original_index: i32,
+    ref_type: CString,
+    id: CString,
     title: CString,
     url: CString,
+    content_json: CString,
 }
 
 impl From<Reference> for CReferenceOwned {
     fn from(v: Reference) -> Self {
-        let Reference { index, title, url } = v;
+        let Reference {
+            index,
+            original_index,
+            ref_type,
+            id,
+            title,
+            url,
+            content,
+        } = v;
         Self {
             index,
+            original_index,
+            ref_type: ref_type.into(),
+            id: id.into(),
             title: title.into(),
             url: url.into(),
+            content_json: content
+                .map(|v| serde_json::to_string(&v).unwrap_or_default())
+                .unwrap_or_default()
+                .into(),
         }
     }
 }
@@ -281,11 +308,23 @@ impl ToFFI for CReferenceOwned {
     type FFIType = CReference;
 
     fn to_ffi_type(&self) -> Self::FFIType {
-        let CReferenceOwned { index, title, url } = self;
+        let CReferenceOwned {
+            index,
+            original_index,
+            ref_type,
+            id,
+            title,
+            url,
+            content_json,
+        } = self;
         CReference {
             index: *index,
+            original_index: *original_index,
+            ref_type: ref_type.to_ffi_type(),
+            id: id.to_ffi_type(),
             title: title.to_ffi_type(),
             url: url.to_ffi_type(),
+            content_json: content_json.to_ffi_type(),
         }
     }
 }
@@ -593,25 +632,40 @@ impl ToFFI for CConversationResponseOwned {
 pub struct CChatStartedPayload {
     /// Conversation identifier
     pub chat_uid: *const c_char,
+    /// Numeric conversation identifier
+    pub chat_id: i64,
     /// Message ID of this round
     pub message_id: *const c_char,
+    /// Error code; empty when absent
+    pub error: *const c_char,
+    /// Error message; empty when absent
+    pub error_message: *const c_char,
 }
 
 #[derive(Debug)]
 pub(crate) struct CChatStartedPayloadOwned {
     chat_uid: CString,
+    chat_id: i64,
     message_id: CString,
+    error: CString,
+    error_message: CString,
 }
 
 impl From<ChatStartedPayload> for CChatStartedPayloadOwned {
     fn from(v: ChatStartedPayload) -> Self {
         let ChatStartedPayload {
             chat_uid,
+            chat_id,
             message_id,
+            error,
+            error_message,
         } = v;
         Self {
             chat_uid: chat_uid.into(),
+            chat_id,
             message_id: message_id.into(),
+            error: error.into(),
+            error_message: error_message.into(),
         }
     }
 }
@@ -622,7 +676,10 @@ impl ToFFI for CChatStartedPayloadOwned {
     fn to_ffi_type(&self) -> Self::FFIType {
         CChatStartedPayload {
             chat_uid: self.chat_uid.to_ffi_type(),
+            chat_id: self.chat_id,
             message_id: self.message_id.to_ffi_type(),
+            error: self.error.to_ffi_type(),
+            error_message: self.error_message.to_ffi_type(),
         }
     }
 }

--- a/java/javasrc/src/main/java/com/longbridge/agent/ChatStartedEvent.java
+++ b/java/javasrc/src/main/java/com/longbridge/agent/ChatStartedEvent.java
@@ -6,6 +6,9 @@ package com.longbridge.agent;
 public final class ChatStartedEvent extends ConversationStreamEvent {
     private String chatUid;
     private String messageId;
+    private long chatId;
+    private String error;
+    private String errorMessage;
 
     /**
      * Returns the conversation identifier.
@@ -25,8 +28,36 @@ public final class ChatStartedEvent extends ConversationStreamEvent {
         return messageId;
     }
 
+    /**
+     * Returns the ID of the owning conversation.
+     *
+     * @return owning conversation ID
+     */
+    public long getChatId() {
+        return chatId;
+    }
+
+    /**
+     * Returns the error detail; empty at start.
+     *
+     * @return error detail
+     */
+    public String getError() {
+        return error;
+    }
+
+    /**
+     * Returns the user-facing error message; empty at start.
+     *
+     * @return user-facing error message
+     */
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
     @Override
     public String toString() {
-        return "ChatStartedEvent [chatUid=" + chatUid + ", messageId=" + messageId + "]";
+        return "ChatStartedEvent [chatUid=" + chatUid + ", messageId=" + messageId + ", chatId=" + chatId
+                + ", error=" + error + ", errorMessage=" + errorMessage + "]";
     }
 }

--- a/java/javasrc/src/main/java/com/longbridge/agent/Reference.java
+++ b/java/javasrc/src/main/java/com/longbridge/agent/Reference.java
@@ -5,8 +5,12 @@ package com.longbridge.agent;
  */
 public class Reference {
     private int index;
+    private int originalIndex;
+    private String refType;
+    private String id;
     private String title;
     private String url;
+    private String content;
 
     /**
      * Returns the reference index.
@@ -18,7 +22,35 @@ public class Reference {
     }
 
     /**
-     * Returns the reference title.
+     * Returns the original index in the source list, before any reranking.
+     *
+     * @return original reference index
+     */
+    public int getOriginalIndex() {
+        return originalIndex;
+    }
+
+    /**
+     * Returns the reference kind, e.g. {@code "NewsArticle"}.
+     *
+     * @return reference kind
+     */
+    public String getRefType() {
+        return refType;
+    }
+
+    /**
+     * Returns the reference id.
+     *
+     * @return reference id
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Returns the reference title. Often empty at the top level — the
+     * human-readable title usually lives in {@link #getContent}.
      *
      * @return reference title
      */
@@ -27,7 +59,8 @@ public class Reference {
     }
 
     /**
-     * Returns the reference URL.
+     * Returns the reference URL. Often empty at the top level — see
+     * {@link #getContent}.
      *
      * @return reference URL
      */
@@ -35,8 +68,21 @@ public class Reference {
         return url;
     }
 
+    /**
+     * Returns the full reference payload as sent by the server ({@code
+     * source}, {@code description}, {@code published_at}, {@code
+     * source_url}, {@code source_logo}, {@code kind}, …), as JSON text. Kept
+     * as raw JSON because the field set varies by {@link #getRefType}.
+     *
+     * @return full reference payload (JSON text), or {@code null}
+     */
+    public String getContent() {
+        return content;
+    }
+
     @Override
     public String toString() {
-        return "Reference [index=" + index + ", title=" + title + ", url=" + url + "]";
+        return "Reference [index=" + index + ", originalIndex=" + originalIndex + ", refType=" + refType + ", id="
+                + id + ", title=" + title + ", url=" + url + ", content=" + content + "]";
     }
 }

--- a/java/src/types/classes.rs
+++ b/java/src/types/classes.rs
@@ -2953,7 +2953,7 @@ impl_java_class!(
 impl_java_class!(
     "com/longbridge/agent/Reference",
     longbridge::agent::Reference,
-    [index, title, url]
+    [index, original_index, ref_type, id, title, url, content]
 );
 
 impl_java_class!(
@@ -3000,7 +3000,7 @@ impl_java_class!(
 impl_java_class!(
     "com/longbridge/agent/ChatStartedEvent",
     longbridge::agent::ChatStartedPayload,
-    [chat_uid, message_id]
+    [chat_uid, message_id, chat_id, error, error_message]
 );
 
 // JNI-side view of `longbridge::agent::WorkflowStartedInputs`, the `inputs`

--- a/nodejs/index.d.ts
+++ b/nodejs/index.d.ts
@@ -3849,6 +3849,12 @@ export interface ChatStartedPayload {
   chatUid: string
   /** Message ID of this round */
   messageId: string
+  /** ID of the owning conversation */
+  chatId: number
+  /** Error detail; empty at start */
+  error: string
+  /** User-facing error message; empty at start */
+  errorMessage: string
 }
 
 /**
@@ -5998,10 +6004,18 @@ export interface RecentBuybacks {
 export interface Reference {
   /** Reference index */
   index: number
+  /** Original index in the source list, before any reranking */
+  originalIndex: number
+  /** Reference kind, e.g. `"NewsArticle"` */
+  refType: string
+  /** Reference id */
+  id: string
   /** Reference title */
   title: string
   /** Reference URL */
   url: string
+  /** Full reference payload as sent by the server; kept as raw JSON because the field set varies by reference `refType` */
+  content?: any
 }
 
 /** Parameters for replacing an attached order */

--- a/nodejs/src/agent/types.rs
+++ b/nodejs/src/agent/types.rs
@@ -126,17 +126,30 @@ impl From<lb::ConversationStatus> for ConversationStatus {
 pub struct Reference {
     /// Reference index
     pub index: i32,
+    /// Original index in the source list, before any reranking
+    pub original_index: i32,
+    /// Reference kind, e.g. `"NewsArticle"`
+    pub ref_type: String,
+    /// Reference id
+    pub id: String,
     /// Reference title
     pub title: String,
     /// Reference URL
     pub url: String,
+    /// Full reference payload as sent by the server; kept as raw JSON
+    /// because the field set varies by reference `ref_type`
+    pub content: Option<serde_json::Value>,
 }
 impl From<lb::Reference> for Reference {
     fn from(v: lb::Reference) -> Self {
         Self {
             index: v.index,
+            original_index: v.original_index,
+            ref_type: v.ref_type,
+            id: v.id,
             title: v.title,
             url: v.url,
+            content: v.content,
         }
     }
 }
@@ -275,12 +288,21 @@ pub struct ChatStartedPayload {
     pub chat_uid: String,
     /// Message ID of this round
     pub message_id: String,
+    /// ID of the owning conversation
+    pub chat_id: i64,
+    /// Error detail; empty at start
+    pub error: String,
+    /// User-facing error message; empty at start
+    pub error_message: String,
 }
 impl From<lb::ChatStartedPayload> for ChatStartedPayload {
     fn from(v: lb::ChatStartedPayload) -> Self {
         Self {
             chat_uid: v.chat_uid,
             message_id: v.message_id,
+            chat_id: v.chat_id,
+            error: v.error,
+            error_message: v.error_message,
         }
     }
 }

--- a/python/pysrc/longbridge/openapi.pyi
+++ b/python/pysrc/longbridge/openapi.pyi
@@ -13420,10 +13420,19 @@ class Reference:
 
     index: int
     """Reference index"""
+    original_index: int
+    """Original index in the source list, before any reranking"""
+    ref_type: str
+    """Reference kind, e.g. ``"NewsArticle"``"""
+    id: str
+    """Reference id"""
     title: str
     """Reference title"""
     url: str
     """Reference URL"""
+    content: Any | None
+    """Full reference payload as sent by the server. Kept as raw JSON
+    because the field set varies by reference ``ref_type``"""
 
 class QuestionOption:
     """One option of a Question."""
@@ -13497,6 +13506,12 @@ class ChatStartedPayload:
     """Conversation identifier"""
     message_id: str
     """Message ID of this round"""
+    chat_id: int
+    """ID of the owning conversation"""
+    error: str
+    """Error detail; empty at start"""
+    error_message: str
+    """User-facing error message; empty at start"""
 
 class MessagePayload:
     """

--- a/python/src/agent/types.rs
+++ b/python/src/agent/types.rs
@@ -118,16 +118,29 @@ pub(crate) enum ConversationStatus {
 #[derive(Debug, Clone)]
 pub(crate) struct Reference {
     pub index: i32,
+    /// Original index in the source list, before any reranking
+    pub original_index: i32,
+    /// Reference kind, e.g. `"NewsArticle"`
+    pub ref_type: String,
+    /// Reference id
+    pub id: String,
     pub title: String,
     pub url: String,
+    /// Full reference payload as sent by the server. Kept as raw JSON
+    /// because the field set varies by reference `ref_type`.
+    pub content: Option<JsonValue>,
 }
 
 impl From<longbridge::agent::Reference> for Reference {
     fn from(v: longbridge::agent::Reference) -> Self {
         Self {
             index: v.index,
+            original_index: v.original_index,
+            ref_type: v.ref_type,
+            id: v.id,
             title: v.title,
             url: v.url,
+            content: v.content.map(JsonValue),
         }
     }
 }
@@ -249,6 +262,12 @@ impl From<longbridge::agent::ConversationResponse> for ConversationResponse {
 pub(crate) struct ChatStartedPayload {
     pub chat_uid: String,
     pub message_id: String,
+    /// ID of the owning conversation
+    pub chat_id: i64,
+    /// Error detail; empty at start
+    pub error: String,
+    /// User-facing error message; empty at start
+    pub error_message: String,
 }
 
 impl From<longbridge::agent::ChatStartedPayload> for ChatStartedPayload {
@@ -256,6 +275,9 @@ impl From<longbridge::agent::ChatStartedPayload> for ChatStartedPayload {
         Self {
             chat_uid: v.chat_uid,
             message_id: v.message_id,
+            chat_id: v.chat_id,
+            error: v.error,
+            error_message: v.error_message,
         }
     }
 }

--- a/rust/src/agent/stream.rs
+++ b/rust/src/agent/stream.rs
@@ -181,6 +181,9 @@ mod tests {
             Ok(ConversationStreamEvent::ChatStarted(ChatStartedPayload {
                 chat_uid: "ct_1".to_string(),
                 message_id: "1".to_string(),
+                chat_id: 0,
+                error: String::new(),
+                error_message: String::new(),
             })),
             Ok(ConversationStreamEvent::HumanInteractionRequired(
                 interrupt_resp,

--- a/rust/src/agent/types.rs
+++ b/rust/src/agent/types.rs
@@ -143,12 +143,28 @@ pub struct Reference {
     /// Reference index
     #[serde(default)]
     pub index: i32,
-    /// Reference title
+    /// Original index in the source list, before any reranking
+    #[serde(default)]
+    pub original_index: i32,
+    /// Reference kind, e.g. `"NewsArticle"`
+    #[serde(default, rename = "type")]
+    pub ref_type: String,
+    /// Reference id
+    #[serde(default)]
+    pub id: String,
+    /// Reference title. Often empty at the top level — the human-readable
+    /// title usually lives in [`content`](Self::content).
     #[serde(default)]
     pub title: String,
-    /// Reference URL
+    /// Reference URL. Often empty at the top level — see
+    /// [`content`](Self::content).
     #[serde(default)]
     pub url: String,
+    /// Full reference payload as sent by the server (`source`, `description`,
+    /// `published_at`, `source_url`, `source_logo`, `kind`, …). Kept as raw
+    /// JSON because the field set varies by reference [`ref_type`](Self::ref_type).
+    #[serde(default)]
+    pub content: Option<serde_json::Value>,
 }
 
 /// One question the Agent needs you to answer
@@ -300,6 +316,15 @@ pub struct ChatStartedPayload {
     /// which is a quoted string) — accept either.
     #[serde(deserialize_with = "crate::serde_utils::deserialize_string_or_int_as_string")]
     pub message_id: String,
+    /// ID of the owning conversation
+    #[serde(default)]
+    pub chat_id: i64,
+    /// Error detail; empty at start
+    #[serde(default)]
+    pub error: String,
+    /// User-facing error message; empty at start
+    #[serde(default)]
+    pub error_message: String,
 }
 
 /// Payload of a `message` SSE event — an incremental text chunk. This is the
@@ -1159,6 +1184,33 @@ mod tests {
         assert!(payload.is_thinking);
         assert_eq!(payload.outputs.query.as_deref(), Some("TSLA stock news"));
         assert_eq!(payload.outputs.references.as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn deserialize_reference_with_nested_content() {
+        // The real wire reference nests the human-readable fields under
+        // `content` and carries `type`/`id`/`original_index` at the top
+        // level; only `index` overlaps the old flat shape.
+        let json = r#"{"type":"NewsArticle","id":"295354885","index":1,"original_index":10,"content":{"source":"智通财经","description":"Jefferies cut Tesla's target.","published_at":"2026-08-10T03:45:02Z","source_url":"https://example.com/a","title":""}}"#;
+        let r: Reference = serde_json::from_str(json).unwrap();
+        assert_eq!(r.index, 1);
+        assert_eq!(r.original_index, 10);
+        assert_eq!(r.ref_type, "NewsArticle");
+        assert_eq!(r.id, "295354885");
+        let content = r.content.expect("content");
+        assert_eq!(content["source"], "智通财经");
+        assert_eq!(content["published_at"], "2026-08-10T03:45:02Z");
+    }
+
+    #[test]
+    fn deserialize_reference_flat_shape_still_works() {
+        // The docs' example uses a flat {index,title,url}; new fields default.
+        let r: Reference = serde_json::from_str(r#"{"index":1,"title":"t","url":"u"}"#).unwrap();
+        assert_eq!(r.index, 1);
+        assert_eq!(r.title, "t");
+        assert_eq!(r.url, "u");
+        assert!(r.content.is_none());
+        assert_eq!(r.ref_type, "");
     }
 
     #[test]

--- a/rust/src/agent/types.rs
+++ b/rust/src/agent/types.rs
@@ -162,7 +162,8 @@ pub struct Reference {
     pub url: String,
     /// Full reference payload as sent by the server (`source`, `description`,
     /// `published_at`, `source_url`, `source_logo`, `kind`, …). Kept as raw
-    /// JSON because the field set varies by reference [`ref_type`](Self::ref_type).
+    /// JSON because the field set varies by reference
+    /// [`ref_type`](Self::ref_type).
     #[serde(default)]
     pub content: Option<serde_json::Value>,
 }


### PR DESCRIPTION
## What

Audited the agent SSE wire against the SDK types (using a recorded real stream) and closed the two places the SDK dropped data the server actually sends.

### `Reference` — was lossy
The real reference nests the human-readable fields under a `content` object and carries `type`/`id`/`original_index` at the top level:
```json
{"type":"NewsArticle","id":"295354885","index":1,"original_index":10,
 "content":{"source":"…","description":"…","published_at":"…","source_url":"…","source_logo":"…","kind":"…","title":""}}
```
The SDK modeled only a flat `{index,title,url}` — so `title`/`url` came back empty for real references and `source`/`description`/`published_at`/… were **lost entirely**. Add `original_index`, `ref_type` (wire `"type"`), `id`, and `content` (raw JSON — the shape varies by `ref_type`). Fixes references wherever they appear: `ConversationResponse.references` and the `message` / `node_tool_use_finished` / `workflow_finished` outputs.

### `ChatStartedPayload`
Add `chat_id` / `error` / `error_message` (present on the wire, mirroring `ChatFinishedPayload`).

## Bindings
Mirrored across **Python, Node.js, Java, C** (+ rust core); the C header is regenerated by cbindgen. `content` is surfaced as raw JSON — `serde_json::Value` in Rust/Python/Node, a JSON string in C (`content_json`) and Java (`getContent()`), following the existing `NodeToolUseOutputs.data` precedent. Each binding crate builds clean; rust core tests cover the nested-content and flat-shape references.

## Why
Downstream (`longbridge-terminal`) renders a References footer and emits references in `--format json`; going through the SDK's lossy `Reference` silently blanked both. This restores fidelity. Companion PR: longbridge/openapi-go#113.