### PR TITLE
fix(agent): tolerate explicit null outputs in streamed conversation events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **All languages:** the AI Agent streamed conversation no longer errors mid-run when the server sends an explicit `"outputs": null`. `WorkflowFinishedPayload.outputs`, `NodeToolUseFinishedPayload.outputs`, and `SubagentFinishedPayload.outputs` were annotated `#[serde(default)]`, which only covers a *missing* key, not an explicit `null` — so a `workflow_finished` / `node_tool_use_finished` / `subagent_finished` event carrying `null` outputs failed to deserialize and aborted the whole event stream (`invalid type: null, expected struct WorkflowOutputs`). These fields now map `null` to the type's default
+
 ## [4.5.0] - 2026-08-14
 
 ### Added

--- a/rust/src/agent/types.rs
+++ b/rust/src/agent/types.rs
@@ -418,7 +418,7 @@ pub struct WorkflowFinishedPayload {
     #[serde(default)]
     pub elapsed_time: f64,
     /// Run outputs
-    #[serde(default)]
+    #[serde(default, deserialize_with = "crate::serde_utils::null_as_default")]
     pub outputs: WorkflowOutputs,
     /// Localized error description; only present when `status` is `failed`
     #[serde(default)]
@@ -648,7 +648,7 @@ pub struct NodeToolUseFinishedPayload {
     #[serde(default)]
     pub is_thinking: bool,
     /// Filtered call results, for display
-    #[serde(default)]
+    #[serde(default, deserialize_with = "crate::serde_utils::null_as_default")]
     pub outputs: NodeToolUseOutputs,
 }
 
@@ -748,7 +748,7 @@ pub struct SubagentFinishedPayload {
     pub error: String,
     /// Subagent result: `goal`, `result`, and the timeline of tool calls it
     /// made
-    #[serde(default)]
+    #[serde(default, deserialize_with = "crate::serde_utils::null_as_default")]
     pub outputs: SubagentOutputs,
 }
 
@@ -1031,6 +1031,21 @@ pub enum ConversationStreamEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn workflow_finished_tolerates_null_outputs() {
+        // A resumed/continued conversation can send `"outputs": null`; that must
+        // deserialize to the default rather than erroring, otherwise the whole
+        // event stream fails mid-turn.
+        let payload: WorkflowFinishedPayload =
+            serde_json::from_str(r#"{"status":"succeeded","outputs":null}"#).unwrap();
+        assert!(payload.outputs.answer.is_none());
+
+        // A missing key must keep working too.
+        let payload: WorkflowFinishedPayload =
+            serde_json::from_str(r#"{"status":"succeeded"}"#).unwrap();
+        assert!(payload.outputs.answer.is_none());
+    }
 
     // The `data` payload of the "Run succeeded" example from
     // https://open.longbridge.com/en/docs/ai/chat/conversation


### PR DESCRIPTION
## Problem

A streamed AI Agent conversation aborts mid-run with:

```
invalid type: null, expected struct WorkflowOutputs
```

when the server sends an explicit `"outputs": null` on a `workflow_finished` event (observed on resumed/continued conversations).

Root cause: `WorkflowFinishedPayload.outputs` (and the sibling `NodeToolUseFinishedPayload.outputs`, `SubagentFinishedPayload.outputs`) were annotated `#[serde(default)]`. `serde`'s `default` only fills a **missing** key — it does not accept an explicit `null`, so `null` fails to deserialize into the struct and the whole event stream errors out.

## Fix

Deserialize these three fields through the existing `serde_utils::null_as_default`, mapping `null` to the type's `Default`. This mirrors how sibling `null` lists (e.g. `Interrupt.questions` / `interactions`) are already handled.

Added a unit test covering both `"outputs": null` and a missing `outputs` key.