### PR TITLE
fix(fundamental): send comparison_symbols as a query array (gateway now accepts it)

### DIFF
--- a/rust/src/fundamental/context.rs
+++ b/rust/src/fundamental/context.rs
@@ -6,31 +6,6 @@ use tracing::{Subscriber, dispatcher, instrument::WithSubscriber};
 
 use crate::{Config, Market, Result, fundamental::types::*};
 
-/// Convert a user-facing symbol (e.g. `700.HK`, `AAPL.US`, `HSI.HK`) to the
-/// backend counter-id form (e.g. `ST/HK/700`, `ST/US/AAPL`, `IX/HK/HSI`).
-///
-/// TODO: temporary shim used only by
-/// [`FundamentalContext::valuation_comparison`] while the gateway does not yet
-/// accept the `comparison_symbols` parameter. Remove it once the gateway
-/// converts the symbols itself, and pass the user symbols straight through.
-/// This is a naive best-effort conversion: it maps dotted-index symbols
-/// (leading `.`, e.g. `.DJI.US`) to the `IX/` prefix and everything else to
-/// `ST/`, so ETF / warrant peers may resolve to the wrong prefix — acceptable
-/// because valuation peers are virtually always equities.
-fn symbol_to_counter_id(symbol: &str) -> String {
-    match symbol.rsplit_once('.') {
-        Some((code, market)) => {
-            let market = market.to_uppercase();
-            if code.starts_with('.') {
-                format!("IX/{market}/{}", &code[1..])
-            } else {
-                format!("ST/{market}/{code}")
-            }
-        }
-        None => symbol.to_string(),
-    }
-}
-
 /// Convert a Unix-seconds string to RFC 3339.
 fn unix_secs_str_to_rfc3339(s: &str) -> String {
     s.parse::<i64>()
@@ -792,31 +767,20 @@ impl FundamentalContext {
         currency: impl Into<String>,
         comparison_symbols: Option<Vec<String>>,
     ) -> Result<ValuationComparisonResponse> {
-        // TODO: The gateway does not yet accept the `comparison_symbols`
-        // parameter (user symbols). Until it does, keep sending the legacy
-        // `comparison_counter_ids` parameter and convert the user symbols to
-        // counter-ids here. Once the gateway supports `comparison_symbols`,
-        // drop this local conversion and pass the user symbols straight
-        // through as `comparison_symbols` (serde_json array string) — the
-        // public API already takes user symbols so no signature change.
         #[derive(Serialize)]
         struct Query {
             symbol: String,
             currency: String,
             #[serde(skip_serializing_if = "Option::is_none")]
-            comparison_counter_ids: Option<String>,
+            comparison_symbols: Option<Vec<String>>,
         }
-        let comparison_counter_ids = comparison_symbols.map(|syms| {
-            let ids: Vec<String> = syms.iter().map(|s| symbol_to_counter_id(s)).collect();
-            serde_json::to_string(&ids).unwrap_or_default()
-        });
         let raw: serde_json::Value = self
             .get(
                 "/v1/quote/compare/valuation",
                 Query {
                     symbol: symbol.into(),
                     currency: currency.into(),
-                    comparison_counter_ids,
+                    comparison_symbols,
                 },
             )
             .await?;


### PR DESCRIPTION
## Background

PR #562 switched `valuation_comparison`'s request parameter from
`comparison_counter_ids` to `comparison_symbols`, but the gateway did not support
it at the time, so a temporary stopgap was added (the SDK locally converted the
symbol back to a counter-id and kept sending the legacy `comparison_counter_ids`).

## Now

The gateway now accepts `comparison_symbols`, but only in the **standard HTTP
array format** (repeated key `comparison_symbols=A&comparison_symbols=B`, or
`[]`), **not** a JSON array string. Measured:

| Format | Test env |
|---|---|
| `comparison_symbols=["9988.HK","3690.HK"]` (JSON string) | ❌ 500 |
| `comparison_symbols=9988.HK&comparison_symbols=3690.HK` (repeated key) | ✅ 200 |
| `comparison_symbols[]=...` (bracket) | ✅ 200 |

## Changes

- Remove the stopgap (`symbol_to_counter_id` shim + local `comparison_counter_ids` conversion).
- Change the query field to `comparison_symbols: Option<Vec<String>>`, serialized by qs into repeated keys — which is exactly what the gateway expects.
- Public API signature unchanged (it has always taken `Option<Vec<String>>` of user symbols).

## Verification

- `cargo clippy --all --all-features` 0 errors, `cargo +nightly fmt` clean.
- **Test env**, real SDK: 700.HK + 2/3/4 comparison symbols; returns the subject plus all comparison peers, symbols all in user-symbol form ✅
- **Production**, real SDK (`openapi.longbridge.com`, re-tested 2026-09-14): 700.HK + 2/3/4 comparison symbols all ✅ 200, returning the subject plus every comparison peer, symbols all in user-symbol form (not counter-ids), with PE/PB/market-cap fields populated. The code 13 previously returned by production no longer reproduces.

## ✅ Release order (blocker resolved)

~~The gateway fix was only on the test env; production still returned code 13 for the new format. This PR had to wait until the gateway production deployment shipped before merge/release.~~

**The gateway's new-format fix is now live in production and has been re-verified (see Verification above). The previous merge/release blocker is satisfied, so this PR can be merged/released normally.**
