### PR TITLE
fix(java): repair broken javadoc @link to disabled getRatings

### DIFF
--- a/java/javasrc/src/main/java/com/longbridge/fundamental/StockRatings.java
+++ b/java/javasrc/src/main/java/com/longbridge/fundamental/StockRatings.java
@@ -1,6 +1,12 @@
 package com.longbridge.fundamental;
 
-/** Response for {@link FundamentalContext#getRatings}. */
+/**
+ * Response for the stock ratings endpoint ({@code getRatings}).
+ *
+ * <p>Note: {@code FundamentalContext.getRatings} is temporarily disabled
+ * (endpoint not yet open — {@code /v1/quote/ratings}), so this type is not
+ * currently returned by any method. It is kept for when the endpoint reopens.
+ */
 public class StockRatings {
     /** Style display name */
     public String styleTxtName;


### PR DESCRIPTION
## 问题
main 的 CI(check-java-sdk)失败:
```
StockRatings.java:3: error: reference not found
/** Response for {@link FundamentalContext#getRatings}. */
```
ratings 暂不开放的下线改动(#562)把 `FundamentalContext.getRatings` 注释掉了,但 `StockRatings` 的类级 javadoc 仍用 `{@link FundamentalContext#getRatings}` 引用它。javadoc 的 doclint 把这个无法解析的引用当作 error,导致 Java SDK 的 javadoc 构建失败。

## 修复
把断链的 `{@link}` 改成纯文本,说明该端点暂不开放、该类保留待接口重开。

## 验证
本地 `mvn javadoc:javadoc` → **BUILD SUCCESS**,无 reference-not-found。

🤖 Generated with [Claude Code](https://claude.com/claude-code)