### PR TITLE
fix(python): build GNU/Linux wheels with manylinux_2_28

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,12 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          args: -i python --release --out dist -m python/Cargo.toml
+          # GNU/Linux wheels must be built in a manylinux container. Building on
+          # the ubuntu-24.04 host without this tags manylinux_2_39 (glibc 2.39),
+          # which pip cannot install on Ubuntu 22.04 (glibc 2.35). manylinux_2_28
+          # covers Ubuntu 20.04/22.04/24.04. Ignored on Windows and macOS.
+          manylinux: ${{ startsWith(matrix.runs-on, 'ubuntu') && '2_28' || 'off' }}
+          args: -i python${{ matrix.python-version }} --release --out dist -m python/Cargo.toml
       - name: Install built wheel
         run: |
           pip install longbridge --no-index --find-links dist --force-reinstall


### PR DESCRIPTION
## Summary

- GNU/Linux Python wheels from the current `build-python-sdk` job are tagged `manylinux_2_39` because they are built on the `ubuntu-24.04` host without a manylinux container.
- Those wheels require glibc ≥ 2.39, so `pip` cannot install them on Ubuntu 22.04 (glibc 2.35). PyPI `longbridge==4.5.0` already shows this (`manylinux_2_39` / `manylinux_2_39_aarch64`).
- This change builds Ubuntu GNU/Linux wheels in a `manylinux_2_28` container (glibc 2.28), which remains installable on Ubuntu 20.04, 22.04, and 24.04. Windows and macOS keep `manylinux: off`. The interpreter flag is aligned with the existing musl job (`-i python${{ matrix.python-version }}`).

## Test plan

- [ ] Confirm GitHub Actions `Release` / `build-python-sdk` GNU/Linux artifacts are tagged `manylinux_2_28` (x86_64 and aarch64), not `manylinux_2_39`.
- [ ] Confirm Windows and macOS wheel tags are unchanged.
- [ ] Install a built GNU/Linux wheel on Ubuntu 22.04 (`pip install longbridge --no-index --find-links dist`) and `import longbridge`.
- [ ] After the next SDK release, confirm PyPI GNU/Linux files are `manylinux_2_28` and installable on Ubuntu 22.04.
