### PR TITLE
style: reformat comments for the current nightly rustfmt

### DIFF
--- a/java/crates/macros/src/lib.rs
+++ b/java/crates/macros/src/lib.rs
@@ -129,8 +129,8 @@ pub fn impl_java_class(input: TokenStream) -> TokenStream {
         let java_field = ident.to_string().to_camel_case();
 
         if let Some(set_type) = args.set_as_opt.as_ref() {
-            // Option<T> field: pass ident.map(set_type::from) as Option<set_type>, which
-            // implements IntoJValue
+            // Option<T> field: pass ident.map(set_type::from) as
+            // Option<set_type>, which implements IntoJValue
             set_fields.push(quote! {
                 crate::types::set_field(env, &obj, #java_field, #ident.map(#set_type::from))?;
             });

--- a/java/src/error.rs
+++ b/java/src/error.rs
@@ -90,9 +90,10 @@ impl JniError {
         match res {
             Ok(obj) => obj,
             Err(_) => {
-                // Building the error object failed (e.g. an exception is already
-                // pending). Fall back to a null error rather than panicking:
-                // this runs on a background callback thread, where a panic would
+                // Building the error object failed (e.g. an exception is
+                // already pending). Fall back to a null error
+                // rather than panicking: this runs on a
+                // background callback thread, where a panic would
                 // unwind across the FFI boundary and abort the whole JVM.
                 let _ = env.exception_clear();
                 JObject::null()
@@ -107,9 +108,9 @@ impl JniError {
             JniError::Other(err) => Self::throw_runtime_error(env, err),
         };
         if let Err(err) = res {
-            // Mapping the error to a Java exception failed. Fall back to a plain
-            // RuntimeException instead of `fatal_error`, which would abort the
-            // JVM outright.
+            // Mapping the error to a Java exception failed. Fall back to a
+            // plain RuntimeException instead of `fatal_error`,
+            // which would abort the JVM outright.
             if !env.exception_check().unwrap_or(false) {
                 let _ = env.throw_new("java/lang/RuntimeException", err.to_string());
             }
@@ -125,8 +126,9 @@ where
         Ok(value) => value,
         Err(err) => {
             // If a Java exception is already pending (e.g. thrown directly by a
-            // `from_jvalue` conversion via `throw_illegal_argument`, or raised by
-            // a Java method we called), keep it instead of throwing a second one.
+            // `from_jvalue` conversion via `throw_illegal_argument`, or raised
+            // by a Java method we called), keep it instead of
+            // throwing a second one.
             if !env.exception_check().unwrap_or(false) {
                 err.throw(env);
             }

--- a/java/src/fundamental_context.rs
+++ b/java/src/fundamental_context.rs
@@ -131,7 +131,8 @@ pub unsafe extern "system" fn Java_com_longbridge_SdkNative_fundamentalContextGe
         let __owned_ctx = context.ctx.clone();
         let symbol: String = get_field(env, &opts, "symbol")?;
         let report: Option<String> = get_field(env, &opts, "report")?;
-        // The core API takes `Option<&'static str>`; leak the short report code.
+        // The core API takes `Option<&'static str>`; leak the short report
+        // code.
         let report: Option<&'static str> = report.map(|s| &*s.leak());
         let cate: Option<String> = get_field(env, &opts, "cate")?;
         async_util::execute(env, callback, async move {

--- a/nodejs/src/fundamental/context.rs
+++ b/nodejs/src/fundamental/context.rs
@@ -324,7 +324,8 @@ impl FundamentalContext {
             .into())
     }
 
-    // ── US-market methods ─────────────────────────────────────────────────────
+    // ── US-market methods
+    // ─────────────────────────────────────────────────────
 
     /// Get US company overview. US token required.
     #[napi]

--- a/python/src/fundamental/context.rs
+++ b/python/src/fundamental/context.rs
@@ -243,7 +243,8 @@ impl FundamentalContext {
             .into())
     }
 
-    // ── US-market methods ─────────────────────────────────────────────────────
+    // ── US-market methods
+    // ─────────────────────────────────────────────────────
 
     /// Get US company overview. US token required.
     fn us_company_overview(&self, symbol: String) -> PyResult<USCompanyOverview> {

--- a/python/src/fundamental/context_async.rs
+++ b/python/src/fundamental/context_async.rs
@@ -248,8 +248,8 @@ impl AsyncFundamentalContext {
 
     // TODO: temporarily disabled — endpoint not yet open (/v1/quote/ratings)
     // /// Get stock ratings. Returns awaitable.
-    // fn ratings(&self, py: Python<'_>, symbol: String) -> PyResult<Py<PyAny>> {
-    //     let ctx = self.ctx.clone();
+    // fn ratings(&self, py: Python<'_>, symbol: String) -> PyResult<Py<PyAny>>
+    // {     let ctx = self.ctx.clone();
     //     pyo3_async_runtimes::tokio::future_into_py(py, async move {
     //         Ok(StockRatings::from(
     //             ctx.ratings(symbol).await.map_err(ErrorNewType)?,
@@ -363,7 +363,8 @@ impl AsyncFundamentalContext {
         .map(|b| b.unbind())
     }
 
-    // ── US-market async methods ───────────────────────────────────────────────
+    // ── US-market async methods
+    // ───────────────────────────────────────────────
 
     /// Get US company overview. US token required. Returns awaitable.
     fn us_company_overview(&self, py: Python<'_>, symbol: String) -> PyResult<Py<PyAny>> {

--- a/rust/crates/httpclient/src/request.rs
+++ b/rust/crates/httpclient/src/request.rs
@@ -300,8 +300,8 @@ where
             .and_then(|value| value.parse().ok())
             .unwrap_or_else(Timestamp::now);
 
-        // Resolve app_key, access_token, optional app_secret, and the data-center
-        // region from the auth config.
+        // Resolve app_key, access_token, optional app_secret, and the
+        // data-center region from the auth config.
         let (app_key, access_token, app_secret, dc_region) = match &config.auth {
             AuthConfig::ApiKey {
                 app_key,
@@ -543,7 +543,8 @@ where
         let status = resp.status();
 
         if status != StatusCode::OK {
-            // Error responses are still a one-shot JSON body ({code, message}), not SSE.
+            // Error responses are still a one-shot JSON body ({code, message}),
+            // not SSE.
             let trace_id = resp
                 .headers()
                 .get("x-trace-id")

--- a/rust/crates/oauth/src/lib.rs
+++ b/rust/crates/oauth/src/lib.rs
@@ -294,8 +294,8 @@ mod tests {
             refresh_token: None,
             expires_at: 9999999999,
         });
-        // The builder holds our storage; a second load on a fresh instance returns
-        // None.
+        // The builder holds our storage; a second load on a fresh instance
+        // returns None.
         let fresh = MemoryStorage::default();
         assert!(fresh.load("x").is_none());
         // But our pre-populated one returns the sentinel.

--- a/rust/src/agent/context.rs
+++ b/rust/src/agent/context.rs
@@ -386,9 +386,10 @@ impl AgentContext {
         let agent_id = agent_id.into();
         let chat_uid = chat_uid.into();
         let message_id = message_id.into();
-        // We already know chat_uid/message_id from the caller (unlike a brand-new
-        // conversation) — seed `started` so the final ConversationResponse carries
-        // them even if the server doesn't re-emit a `chat_started` event here.
+        // We already know chat_uid/message_id from the caller (unlike a
+        // brand-new conversation) — seed `started` so the final
+        // ConversationResponse carries them even if the server doesn't
+        // re-emit a `chat_started` event here.
         let mut started = Some((chat_uid.clone(), message_id.clone()));
         let raw = self
             .0
@@ -519,8 +520,8 @@ mod tests {
     }
 
     // https://github.com/longbridge/developers/pull/1176 — an interrupted
-    // run's stream never emits `workflow_finished`; `human_interaction_required`
-    // is the terminal event instead.
+    // run's stream never emits `workflow_finished`;
+    // `human_interaction_required` is the terminal event instead.
     const HUMAN_INTERACTION_REQUIRED: &str = r#"{"event":"human_interaction_required","workflow_run_id":"wr_1","data":{"node_id":"n_ask_human","tool_call_id":"call_abc123","questions":[{"question":"Which time range would you like to check?","options":[{"description":"Past week"},{"description":"Past month"}],"multi_select":false}],"message_id":43,"chat_id":1001}}"#;
 
     #[test]

--- a/rust/src/agent/types.rs
+++ b/rust/src/agent/types.rs
@@ -1044,9 +1044,9 @@ mod tests {
 
     #[test]
     fn workflow_finished_tolerates_null_outputs() {
-        // A resumed/continued conversation can send `"outputs": null`; that must
-        // deserialize to the default rather than erroring, otherwise the whole
-        // event stream fails mid-turn.
+        // A resumed/continued conversation can send `"outputs": null`; that
+        // must deserialize to the default rather than erroring,
+        // otherwise the whole event stream fails mid-turn.
         let payload: WorkflowFinishedPayload =
             serde_json::from_str(r#"{"status":"succeeded","outputs":null}"#).unwrap();
         assert!(payload.outputs.answer.is_none());

--- a/rust/src/blocking/fundamental.rs
+++ b/rust/src/blocking/fundamental.rs
@@ -350,7 +350,8 @@ impl FundamentalContextSync {
         })
     }
 
-    // ── US-market blocking wrappers ───────────────────────────────────────────
+    // ── US-market blocking wrappers
+    // ───────────────────────────────────────────
 
     /// Get US company overview (blocking)
     pub fn us_company_overview(

--- a/rust/src/blocking/quote.rs
+++ b/rust/src/blocking/quote.rs
@@ -1214,7 +1214,8 @@ impl QuoteContextSync {
             .call(move |ctx| async move { ctx.short_trades(symbol, count).await })
     }
 
-    // ── US-market blocking wrappers ───────────────────────────────────────────
+    // ── US-market blocking wrappers
+    // ───────────────────────────────────────────
 
     /// Get cryptocurrency market overview (blocking)
     pub fn us_crypto_overview(

--- a/rust/src/blocking/trade.rs
+++ b/rust/src/blocking/trade.rs
@@ -483,7 +483,8 @@ impl TradeContextSync {
             .call(move |ctx| async move { ctx.estimate_max_purchase_quantity(opts).await })
     }
 
-    // ── US-market blocking wrappers ───────────────────────────────────────────
+    // ── US-market blocking wrappers
+    // ───────────────────────────────────────────
 
     /// Query the paginated US order list (blocking)
     pub fn us_query_orders(&self, opts: GetUSHistoryOrders) -> Result<QueryUSOrdersResponse> {

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -563,8 +563,9 @@ impl Config {
                 request.headers_mut().append(name, val);
             }
         }
-        // Route the upgrade to the data center matching the credential's region,
-        // unless the caller already set the header via a custom header.
+        // Route the upgrade to the data center matching the credential's
+        // region, unless the caller already set the header via a custom
+        // header.
         if !self
             .custom_headers
             .keys()

--- a/rust/src/fundamental/context.rs
+++ b/rust/src/fundamental/context.rs
@@ -1085,7 +1085,8 @@ impl FundamentalContext {
         Ok(MacroeconomicResponse { info, data, count })
     }
 
-    // ── US-market APIs (US token required) ────────────────────────────────────
+    // ── US-market APIs (US token required)
+    // ────────────────────────────────────
 
     /// Get US company overview.
     ///

--- a/rust/src/quote/context.rs
+++ b/rust/src/quote/context.rs
@@ -2264,7 +2264,8 @@ impl QuoteContext {
         Ok(())
     }
 
-    // ── US-market APIs ────────────────────────────────────────────────────────
+    // ── US-market APIs
+    // ────────────────────────────────────────────────────────
 
     /// Get cryptocurrency market overview.
     ///

--- a/rust/src/trade/context.rs
+++ b/rust/src/trade/context.rs
@@ -914,7 +914,8 @@ impl TradeContext {
             .0)
     }
 
-    // ── US-market APIs ────────────────────────────────────────────────────────
+    // ── US-market APIs
+    // ────────────────────────────────────────────────────────
 
     /// Query the paginated US order list.
     ///


### PR DESCRIPTION
## 问题
main 的 `check-format` CI 失败(#582 合并后触发的那次跑):
```
Diff in java/crates/macros/src/lib.rs:129
Diff in java/src/error.rs:90 ...
```

## 根因
- `check-format` job 用 **未固定版本的 nightly**(`toolchain: nightly`)跑 `cargo fmt --all -- --check`;
- `.rustfmt.toml` 开了 unstable 的 `wrap_comments = true`,其注释折行算法在近期 nightly 里变了;
- 之前用旧 nightly 格式化过的注释,在新 nightly 下不再满足 `--check`。

跟 #582 无关(#582 只改了一个 `.java` 文件,cargo fmt 不处理 Java)—— 只是 #582 那次 push 触发了用新 nightly 的检查。

## 修复
用当前 nightly(rustfmt 1.10.0-nightly, 2026-08-30)重排受影响文件的注释。**纯注释/空白,无任何代码逻辑改动**(已核对:非注释改动行为空)。

## 验证
本地 `cargo +nightly fmt --all -- --check` → **exit 0、无 diff**。

> 备注:根因是 CI 用漂移的 nightly + unstable `wrap_comments`,以后 nightly 再变还会复发。若要彻底稳定,可考虑在 CI 固定 nightly 日期(如 `toolchain: nightly-2026-08-30`)——本 PR 未做此改动,留给维护者决定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)