### PR TITLE
docs(quote): refresh option Greek descriptions on SecurityCalcIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **All SDKs:** refreshed the option Greek field descriptions on `SecurityCalcIndex` (`calc_indexes`) — `delta` / `gamma` / `theta` / `vega` / `rho` — to match the Calc Index interface documentation. Notably, `theta` is now documented as a per-day value: the server divides the raw annualized value by 365, so the returned `theta` is already daily (previously the doc said the raw value was annualized by 252 and had to be divided by 252). Doc comments only — no field or behaviour changes
+
 ### Breaking changes
 
 - **All SDKs:** removed `GridContext.submit_strategy_questionnaire` (`POST /v1/record/questionnaire`) and its `SubmitStrategyQuestionnaireOptions` type. The endpoint has been retired; the strategy risk-disclosure record is no longer submitted through the OpenAPI SDK. Removed across Rust (incl. blocking), C, C++, Java, Node.js, and Python bindings

--- a/c/csrc/include/longbridge.h
+++ b/c/csrc/include/longbridge.h
@@ -6973,23 +6973,31 @@ typedef struct lb_security_calc_index_t {
    */
   const int64_t *open_interest;
   /**
-   * Delta
+   * Delta. Measures the expected change in option price for a $1 move in the
+   * underlying asset price.
    */
   const struct lb_decimal_t *delta;
   /**
-   * Gamma
+   * Gamma. Measures the expected change in Delta for a $1 move in the
+   * underlying asset price.
    */
   const struct lb_decimal_t *gamma;
   /**
-   * Theta
+   * Theta. Measures the expected change in option price as one day passes;
+   * the raw value has been divided by 365 to convert to a daily value,
+   * representing the impact of one day's time decay on the option price.
    */
   const struct lb_decimal_t *theta;
   /**
-   * Vega
+   * Vega. Measures the expected change in option price when implied
+   * volatility (IV) moves by 1 (i.e. 100%); divide the raw value by 100 to
+   * get the expected price change per 1% move in IV.
    */
   const struct lb_decimal_t *vega;
   /**
-   * Rho
+   * Rho. Measures the expected change in option price when the risk-free
+   * interest rate moves by 1 (i.e. 100%); divide the raw value by 100 to get
+   * the expected price change per 1% move in the interest rate.
    */
   const struct lb_decimal_t *rho;
 } lb_security_calc_index_t;

--- a/c/src/quote_context/types.rs
+++ b/c/src/quote_context/types.rs
@@ -2258,15 +2258,23 @@ pub struct CSecurityCalcIndex {
     pub balance_point: *const CDecimal,
     /// Open interest
     pub open_interest: *const i64,
-    /// Delta
+    /// Delta. Measures the expected change in option price for a $1 move in the
+    /// underlying asset price.
     pub delta: *const CDecimal,
-    /// Gamma
+    /// Gamma. Measures the expected change in Delta for a $1 move in the
+    /// underlying asset price.
     pub gamma: *const CDecimal,
-    /// Theta
+    /// Theta. Measures the expected change in option price as one day passes;
+    /// the raw value has been divided by 365 to convert to a daily value,
+    /// representing the impact of one day's time decay on the option price.
     pub theta: *const CDecimal,
-    /// Vega
+    /// Vega. Measures the expected change in option price when implied
+    /// volatility (IV) moves by 1 (i.e. 100%); divide the raw value by 100 to
+    /// get the expected price change per 1% move in IV.
     pub vega: *const CDecimal,
-    /// Rho
+    /// Rho. Measures the expected change in option price when the risk-free
+    /// interest rate moves by 1 (i.e. 100%); divide the raw value by 100 to get
+    /// the expected price change per 1% move in the interest rate.
     pub rho: *const CDecimal,
 }
 

--- a/cpp/include/types.hpp
+++ b/cpp/include/types.hpp
@@ -1021,15 +1021,23 @@ struct SecurityCalcIndex
   std::optional<Decimal> balance_point;
   /// Open interest
   std::optional<int64_t> open_interest;
-  /// Delta
+  /// Delta. Measures the expected change in option price for a $1 move in the
+  /// underlying asset price.
   std::optional<Decimal> delta;
-  /// Gamma
+  /// Gamma. Measures the expected change in Delta for a $1 move in the
+  /// underlying asset price.
   std::optional<Decimal> gamma;
-  /// Theta
+  /// Theta. Measures the expected change in option price as one day passes; the
+  /// raw value has been divided by 365 to convert to a daily value,
+  /// representing the impact of one day's time decay on the option price.
   std::optional<Decimal> theta;
-  /// Vega
+  /// Vega. Measures the expected change in option price when implied volatility
+  /// (IV) moves by 1 (i.e. 100%); divide the raw value by 100 to get the
+  /// expected price change per 1% move in IV.
   std::optional<Decimal> vega;
-  /// Rho
+  /// Rho. Measures the expected change in option price when the risk-free
+  /// interest rate moves by 1 (i.e. 100%); divide the raw value by 100 to get
+  /// the expected price change per 1% move in the interest rate.
   std::optional<Decimal> rho;
 };
 

--- a/java/javasrc/src/main/java/com/longbridge/quote/SecurityCalcIndex.java
+++ b/java/javasrc/src/main/java/com/longbridge/quote/SecurityCalcIndex.java
@@ -374,7 +374,8 @@ public class SecurityCalcIndex {
     }
 
     /**
-     * Returns the delta.
+     * Returns the delta. Measures the expected change in option price for a $1
+     * move in the underlying asset price.
      *
      * @return the delta
      */
@@ -383,7 +384,8 @@ public class SecurityCalcIndex {
     }
 
     /**
-     * Returns the gamma.
+     * Returns the gamma. Measures the expected change in Delta for a $1 move in
+     * the underlying asset price.
      *
      * @return the gamma
      */
@@ -392,7 +394,9 @@ public class SecurityCalcIndex {
     }
 
     /**
-     * Returns the theta.
+     * Returns the theta. Measures the expected change in option price as one day
+     * passes; the raw value has been divided by 365 to convert to a daily value,
+     * representing the impact of one day's time decay on the option price.
      *
      * @return the theta
      */
@@ -401,7 +405,9 @@ public class SecurityCalcIndex {
     }
 
     /**
-     * Returns the vega.
+     * Returns the vega. Measures the expected change in option price when implied
+     * volatility (IV) moves by 1 (i.e. 100%); divide the raw value by 100 to get
+     * the expected price change per 1% move in IV.
      *
      * @return the vega
      */
@@ -410,7 +416,9 @@ public class SecurityCalcIndex {
     }
 
     /**
-     * Returns the rho.
+     * Returns the rho. Measures the expected change in option price when the
+     * risk-free interest rate moves by 1 (i.e. 100%); divide the raw value by 100
+     * to get the expected price change per 1% move in the interest rate.
      *
      * @return the rho
      */

--- a/nodejs/index.d.ts
+++ b/nodejs/index.d.ts
@@ -2853,34 +2853,32 @@ export declare class SecurityCalcIndex {
   get balancePoint(): Decimal | null
   /** Open interest */
   get openInterest(): number | null
-  /** Delta */
+  /**
+   * Delta. Measures the expected change in option price for a $1 move in the
+   * underlying asset price.
+   */
   get delta(): Decimal | null
-  /** Gamma */
+  /**
+   * Gamma. Measures the expected change in Delta for a $1 move in the
+   * underlying asset price.
+   */
   get gamma(): Decimal | null
   /**
-   * Theta
-   *
-   * The raw value returned by the API is annualized (scaled by 252 trading
-   * days per year). To obtain the standard per-calendar-day theta, divide
-   * by 252: `theta / 252`.
+   * Theta. Measures the expected change in option price as one day passes;
+   * the raw value has been divided by 365 to convert to a daily value,
+   * representing the impact of one day's time decay on the option price.
    */
   get theta(): Decimal | null
   /**
-   * Vega
-   *
-   * The raw value returned by the API is expressed per 1 percentage-point
-   * change in implied volatility (i.e. the value has been multiplied by
-   * 100). To obtain the standard vega (per unit change in IV), divide by
-   * 100: `vega / 100`.
+   * Vega. Measures the expected change in option price when implied
+   * volatility (IV) moves by 1 (i.e. 100%); divide the raw value by 100 to
+   * get the expected price change per 1% move in IV.
    */
   get vega(): Decimal | null
   /**
-   * Rho
-   *
-   * The raw value returned by the API is expressed per 1 percentage-point
-   * change in the risk-free rate (i.e. the value has been multiplied by
-   * 100). To obtain the standard rho (per unit change in rate), divide by
-   * 100: `rho / 100`.
+   * Rho. Measures the expected change in option price when the risk-free
+   * interest rate moves by 1 (i.e. 100%); divide the raw value by 100 to get
+   * the expected price change per 1% move in the interest rate.
    */
   get rho(): Decimal | null
 }

--- a/nodejs/src/quote/types.rs
+++ b/nodejs/src/quote/types.rs
@@ -1332,33 +1332,27 @@ pub struct SecurityCalcIndex {
     /// Open interest
     #[js(opt)]
     open_interest: Option<i64>,
-    /// Delta
+    /// Delta. Measures the expected change in option price for a $1 move in the
+    /// underlying asset price.
     #[js(opt)]
     delta: Option<Decimal>,
-    /// Gamma
+    /// Gamma. Measures the expected change in Delta for a $1 move in the
+    /// underlying asset price.
     #[js(opt)]
     gamma: Option<Decimal>,
-    /// Theta
-    ///
-    /// The raw value returned by the API is annualized (scaled by 252 trading
-    /// days per year). To obtain the standard per-calendar-day theta, divide
-    /// by 252: `theta / 252`.
+    /// Theta. Measures the expected change in option price as one day passes;
+    /// the raw value has been divided by 365 to convert to a daily value,
+    /// representing the impact of one day's time decay on the option price.
     #[js(opt)]
     theta: Option<Decimal>,
-    /// Vega
-    ///
-    /// The raw value returned by the API is expressed per 1 percentage-point
-    /// change in implied volatility (i.e. the value has been multiplied by
-    /// 100). To obtain the standard vega (per unit change in IV), divide by
-    /// 100: `vega / 100`.
+    /// Vega. Measures the expected change in option price when implied
+    /// volatility (IV) moves by 1 (i.e. 100%); divide the raw value by 100 to
+    /// get the expected price change per 1% move in IV.
     #[js(opt)]
     vega: Option<Decimal>,
-    /// Rho
-    ///
-    /// The raw value returned by the API is expressed per 1 percentage-point
-    /// change in the risk-free rate (i.e. the value has been multiplied by
-    /// 100). To obtain the standard rho (per unit change in rate), divide by
-    /// 100: `rho / 100`.
+    /// Rho. Measures the expected change in option price when the risk-free
+    /// interest rate moves by 1 (i.e. 100%); divide the raw value by 100 to get
+    /// the expected price change per 1% move in the interest rate.
     #[js(opt)]
     rho: Option<Decimal>,
 }

--- a/python/pysrc/longbridge/openapi.pyi
+++ b/python/pysrc/longbridge/openapi.pyi
@@ -2807,27 +2807,35 @@ class SecurityCalcIndex:
 
     delta: Optional[Decimal]
     """
-    Delta
+    Delta. Measures the expected change in option price for a $1 move in the
+    underlying asset price.
     """
 
     gamma: Optional[Decimal]
     """
-    Gamma
+    Gamma. Measures the expected change in Delta for a $1 move in the
+    underlying asset price.
     """
 
     theta: Optional[Decimal]
     """
-    Theta
+    Theta. Measures the expected change in option price as one day passes; the
+    raw value has been divided by 365 to convert to a daily value, representing
+    the impact of one day's time decay on the option price.
     """
 
     vega: Optional[Decimal]
     """
-    Vega
+    Vega. Measures the expected change in option price when implied volatility
+    (IV) moves by 1 (i.e. 100%); divide the raw value by 100 to get the expected
+    price change per 1% move in IV.
     """
 
     rho: Optional[Decimal]
     """
-    Rho
+    Rho. Measures the expected change in option price when the risk-free
+    interest rate moves by 1 (i.e. 100%); divide the raw value by 100 to get the
+    expected price change per 1% move in the interest rate.
     """
 
 class QuotePackageDetail:

--- a/python/src/quote/types.rs
+++ b/python/src/quote/types.rs
@@ -1295,33 +1295,27 @@ pub(crate) struct SecurityCalcIndex {
     /// Open interest
     #[py(opt)]
     open_interest: Option<i64>,
-    /// Delta
+    /// Delta. Measures the expected change in option price for a $1 move in the
+    /// underlying asset price.
     #[py(opt)]
     delta: Option<PyDecimal>,
-    /// Gamma
+    /// Gamma. Measures the expected change in Delta for a $1 move in the
+    /// underlying asset price.
     #[py(opt)]
     gamma: Option<PyDecimal>,
-    /// Theta
-    ///
-    /// The raw value returned by the API is annualized (scaled by 252 trading
-    /// days per year). To obtain the standard per-calendar-day theta, divide
-    /// by 252: `theta / 252`.
+    /// Theta. Measures the expected change in option price as one day passes;
+    /// the raw value has been divided by 365 to convert to a daily value,
+    /// representing the impact of one day's time decay on the option price.
     #[py(opt)]
     theta: Option<PyDecimal>,
-    /// Vega
-    ///
-    /// The raw value returned by the API is expressed per 1 percentage-point
-    /// change in implied volatility (i.e. the value has been multiplied by
-    /// 100). To obtain the standard vega (per unit change in IV), divide by
-    /// 100: `vega / 100`.
+    /// Vega. Measures the expected change in option price when implied
+    /// volatility (IV) moves by 1 (i.e. 100%); divide the raw value by 100 to
+    /// get the expected price change per 1% move in IV.
     #[py(opt)]
     vega: Option<PyDecimal>,
-    /// Rho
-    ///
-    /// The raw value returned by the API is expressed per 1 percentage-point
-    /// change in the risk-free rate (i.e. the value has been multiplied by
-    /// 100). To obtain the standard rho (per unit change in rate), divide by
-    /// 100: `rho / 100`.
+    /// Rho. Measures the expected change in option price when the risk-free
+    /// interest rate moves by 1 (i.e. 100%); divide the raw value by 100 to get
+    /// the expected price change per 1% move in the interest rate.
     #[py(opt)]
     rho: Option<PyDecimal>,
 }

--- a/rust/src/quote/types.rs
+++ b/rust/src/quote/types.rs
@@ -1726,29 +1726,23 @@ pub struct SecurityCalcIndex {
     pub balance_point: Option<Decimal>,
     /// Open interest
     pub open_interest: Option<i64>,
-    /// Delta
+    /// Delta. Measures the expected change in option price for a $1 move in the
+    /// underlying asset price.
     pub delta: Option<Decimal>,
-    /// Gamma
+    /// Gamma. Measures the expected change in Delta for a $1 move in the
+    /// underlying asset price.
     pub gamma: Option<Decimal>,
-    /// Theta
-    ///
-    /// The raw value returned by the API is annualized (scaled by 252 trading
-    /// days per year). To obtain the standard per-calendar-day theta, divide
-    /// by 252: `theta / 252`.
+    /// Theta. Measures the expected change in option price as one day passes;
+    /// the raw value has been divided by 365 to convert to a daily value,
+    /// representing the impact of one day's time decay on the option price.
     pub theta: Option<Decimal>,
-    /// Vega
-    ///
-    /// The raw value returned by the API is expressed per 1 percentage-point
-    /// change in implied volatility (i.e. the value has been multiplied by
-    /// 100). To obtain the standard vega (per unit change in IV), divide by
-    /// 100: `vega / 100`.
+    /// Vega. Measures the expected change in option price when implied
+    /// volatility (IV) moves by 1 (i.e. 100%); divide the raw value by 100 to
+    /// get the expected price change per 1% move in IV.
     pub vega: Option<Decimal>,
-    /// Rho
-    ///
-    /// The raw value returned by the API is expressed per 1 percentage-point
-    /// change in the risk-free rate (i.e. the value has been multiplied by
-    /// 100). To obtain the standard rho (per unit change in rate), divide by
-    /// 100: `rho / 100`.
+    /// Rho. Measures the expected change in option price when the risk-free
+    /// interest rate moves by 1 (i.e. 100%); divide the raw value by 100 to get
+    /// the expected price change per 1% move in the interest rate.
     pub rho: Option<Decimal>,
 }
 


### PR DESCRIPTION
Update the delta / gamma / theta / vega / rho field descriptions on `SecurityCalcIndex` (calc_indexes) across all six SDK layers to match the Calc Index interface docs.

Key change: **theta is now a per-day value** — the server divides the raw annualized theta by 365, so the returned value is already daily. Previously the docs said the raw value was annualized (×252) and had to be divided by 252. vega/rho keep the /100 note.

Doc comments only; C header and Node `index.d.ts` regenerated. No field or behaviour changes. clippy --all --all-features and cargo fmt --check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)